### PR TITLE
feat: translate CTO support service page

### DIFF
--- a/src/pages/fr/prestations/accompagnement-cto/index.astro
+++ b/src/pages/fr/prestations/accompagnement-cto/index.astro
@@ -1,4 +1,6 @@
 ---
+import { match } from 'ts-pattern';
+
 import { getLink } from '@/lib/link';
 import { getDataForPeopleCarousel } from '@/lib/people';
 import { breadcrumbEntries } from '@/components/breadcrumb/utils';
@@ -65,352 +67,784 @@ const breadcrumb = breadcrumbEntries(locale)((entry) => [
       </div>
 
       <Prose>
-        <h2>Qu'est-ce que l'accompagnement CTO ?</h2>
-        <p>
-          L'accompagnement CTO (Chief Technology Officer) consiste à vous
-          apporter une <strong>expertise technique stratégique</strong> pour guider
-          les décisions technologiques de votre entreprise ou de votre projet. Que
-          vous soyez une startup sans CTO en interne, une PME qui souhaite structurer
-          sa stratégie tech, ou une entreprise qui a besoin d'un regard externe sur
-          ses choix techniques, nous sommes là pour vous accompagner.
-        </p>
-        <p>
-          Le rôle d'un CTO ne se limite pas à la technique pure. Il englobe
-          également la <strong>gestion d'équipe</strong>, le <strong
-            >recrutement technique</strong
-          >, la <strong>définition de la roadmap produit</strong>, l'<strong
-            >architecture logicielle</strong
-          >, le <strong>choix des technologies</strong> et la mise en place de
-          <strong>bonnes pratiques de développement</strong>.
-        </p>
-        <p>
-          Notre accompagnement s'adapte à vos besoins : nous pouvons intervenir
-          de manière <strong>ponctuelle</strong> pour un audit technique ou une problématique
-          spécifique, ou de manière <strong>récurrente</strong> en tant que CTO as
-          a Service pour structurer et faire évoluer votre stratégie technique sur
-          le long terme.
-        </p>
-        <p>
-          Avec notre expérience dans le <a
-            href={getLink('/fr/prestations/developpement-web', locale, {})}
-            >développement web</a
-          >, le <a
-            href={getLink('/fr/prestations/developpement-mobile', locale, {})}
-            >développement mobile</a
-          > et l'<a href={getLink('/fr/prestations/ux-design', locale, {})}
-            >UX design</a
-          >, nous avons une vision complète du cycle de vie d'un produit
-          numérique et pouvons vous conseiller de manière holistique.
-        </p>
+        {
+          match(locale)
+            .with('fr', () => (
+              <>
+                <h2>Qu'est-ce que l'accompagnement CTO ?</h2>
+                <p>
+                  L'accompagnement CTO (Chief Technology Officer) consiste à
+                  vous apporter une{' '}
+                  <strong>expertise technique stratégique</strong> pour guider
+                  les décisions technologiques de votre entreprise ou de votre
+                  projet. Que vous soyez une startup sans CTO en interne, une
+                  PME qui souhaite structurer sa stratégie tech, ou une
+                  entreprise qui a besoin d'un regard externe sur ses choix
+                  techniques, nous sommes là pour vous accompagner.
+                </p>
+                <p>
+                  Le rôle d'un CTO ne se limite pas à la technique pure. Il
+                  englobe également la <strong>gestion d'équipe</strong>, le{' '}
+                  <strong>recrutement technique</strong>, la{' '}
+                  <strong>définition de la roadmap produit</strong>, l'
+                  <strong>architecture logicielle</strong>, le{' '}
+                  <strong>choix des technologies</strong> et la mise en place de{' '}
+                  <strong>bonnes pratiques de développement</strong>.
+                </p>
+                <p>
+                  Notre accompagnement s'adapte à vos besoins : nous pouvons
+                  intervenir de manière <strong>ponctuelle</strong> pour un
+                  audit technique ou une problématique spécifique, ou de manière{' '}
+                  <strong>récurrente</strong> en tant que CTO as a Service pour
+                  structurer et faire évoluer votre stratégie technique sur le
+                  long terme.
+                </p>
+                <p>
+                  Avec notre expérience dans le{' '}
+                  <a
+                    href={getLink(
+                      '/fr/prestations/developpement-web',
+                      locale,
+                      {}
+                    )}
+                  >
+                    développement web
+                  </a>
+                  , le{' '}
+                  <a
+                    href={getLink(
+                      '/fr/prestations/developpement-mobile',
+                      locale,
+                      {}
+                    )}
+                  >
+                    développement mobile
+                  </a>{' '}
+                  et l'
+                  <a href={getLink('/fr/prestations/ux-design', locale, {})}>
+                    UX design
+                  </a>
+                  , nous avons une vision complète du cycle de vie d'un produit
+                  numérique et pouvons vous conseiller de manière holistique.
+                </p>
+              </>
+            ))
+            .with('en', () => (
+              <>
+                <h2>What is CTO support?</h2>
+                <p>
+                  CTO (Chief Technology Officer) support involves providing you
+                  with <strong>strategic technical expertise</strong> to guide
+                  the technological decisions of your company or project.
+                  Whether you're a startup without an in-house CTO, an SME
+                  looking to structure its tech strategy, or a company that
+                  needs an external perspective on its technical choices, we're
+                  here to support you.
+                </p>
+                <p>
+                  The role of a CTO goes beyond pure technology. It also
+                  encompasses <strong>team management</strong>,{' '}
+                  <strong>technical recruitment</strong>,{' '}
+                  <strong>product roadmap definition</strong>,{' '}
+                  <strong>software architecture</strong>,{' '}
+                  <strong>technology selection</strong>, and implementing{' '}
+                  <strong>development best practices</strong>.
+                </p>
+                <p>
+                  Our support adapts to your needs: we can intervene on a{' '}
+                  <strong>one-off basis</strong> for a technical audit or a
+                  specific issue, or on a <strong>recurring basis</strong> as
+                  CTO as a Service to structure and evolve your technical
+                  strategy over the long term.
+                </p>
+                <p>
+                  With our experience in{' '}
+                  <a
+                    href={getLink(
+                      '/fr/prestations/developpement-web',
+                      locale,
+                      {}
+                    )}
+                  >
+                    web development
+                  </a>
+                  ,{' '}
+                  <a
+                    href={getLink(
+                      '/fr/prestations/developpement-mobile',
+                      locale,
+                      {}
+                    )}
+                  >
+                    mobile development
+                  </a>
+                  , and{' '}
+                  <a href={getLink('/fr/prestations/ux-design', locale, {})}>
+                    UX design
+                  </a>
+                  , we have a complete vision of the digital product lifecycle
+                  and can advise you holistically.
+                </p>
+              </>
+            ))
+            .exhaustive()
+        }
       </Prose>
     </div>
   </Container>
   <Container class="pt-0">
     <ContactCard
       locale={locale}
-      title="On est disponible"
-      subtitle="Discutons de vos enjeux techniques et trouvons ensemble les solutions adaptées à votre contexte."
+      title={match(locale)
+        .with('fr', () => 'On est disponible')
+        .with('en', () => "We're available")
+        .exhaustive()}
+      subtitle={match(locale)
+        .with(
+          'fr',
+          () =>
+            'Discutons de vos enjeux techniques et trouvons ensemble les solutions adaptées à votre contexte.'
+        )
+        .with(
+          'en',
+          () =>
+            "Let's discuss your technical challenges and find the right solutions for your context together."
+        )
+        .exhaustive()}
       peopleIds={['rudy-baer', 'ivan-dalmet']}
     />
   </Container>
 
   <Container>
     <Prose>
-      <h2>Accompagnement CTO sur mesure</h2>
-      <p>
-        Que vous ayez besoin d'un <strong>audit technique</strong>, de définir
-        votre <strong>architecture applicative</strong>, de structurer vos <strong
-          >équipes de développement</strong
-        > ou de vous faire accompagner dans vos <strong
-          >choix stratégiques</strong
-        >, nous mettons à votre disposition notre expertise de plus de 15 ans
-        dans le développement de produits numériques.
-      </p>
-      <p>
-        Nous intervenons sur des problématiques variées : <strong
-          >refonte technique</strong
-        >, <strong>optimisation des performances</strong>, <strong
-          >mise en place de processus</strong
-        > (CI/CD, tests, revue de code), <strong
-          >structuration de la dette technique</strong
-        >, <strong>choix de stack technologique</strong>, <strong
-          >recrutement et montée en compétences des équipes</strong
-        >.
-      </p>
-      <p>
-        Notre approche est pragmatique et orientée résultats. Nous ne nous
-        contentons pas de recommandations théoriques : nous vous accompagnons
-        dans la mise en œuvre concrète des solutions identifiées, en nous
-        appuyant sur notre expérience terrain du développement.
-      </p>
+      {
+        match(locale)
+          .with('fr', () => (
+            <>
+              <h2>Accompagnement CTO sur mesure</h2>
+              <p>
+                Que vous ayez besoin d'un <strong>audit technique</strong>, de
+                définir votre <strong>architecture applicative</strong>, de
+                structurer vos <strong>équipes de développement</strong> ou de
+                vous faire accompagner dans vos{' '}
+                <strong>choix stratégiques</strong>, nous mettons à votre
+                disposition notre expertise de plus de 15 ans dans le
+                développement de produits numériques.
+              </p>
+              <p>
+                Nous intervenons sur des problématiques variées :{' '}
+                <strong>refonte technique</strong>,{' '}
+                <strong>optimisation des performances</strong>,{' '}
+                <strong>mise en place de processus</strong> (CI/CD, tests, revue
+                de code), <strong>structuration de la dette technique</strong>,{' '}
+                <strong>choix de stack technologique</strong>,{' '}
+                <strong>
+                  recrutement et montée en compétences des équipes
+                </strong>
+                .
+              </p>
+              <p>
+                Notre approche est pragmatique et orientée résultats. Nous ne
+                nous contentons pas de recommandations théoriques : nous vous
+                accompagnons dans la mise en œuvre concrète des solutions
+                identifiées, en nous appuyant sur notre expérience terrain du
+                développement.
+              </p>
+            </>
+          ))
+          .with('en', () => (
+            <>
+              <h2>Tailored CTO support</h2>
+              <p>
+                Whether you need a <strong>technical audit</strong>, to define
+                your <strong>application architecture</strong>, to structure
+                your <strong>development teams</strong>, or to be supported in
+                your <strong>strategic decisions</strong>, we put our 15+ years
+                of expertise in digital product development at your disposal.
+              </p>
+              <p>
+                We address a wide range of challenges:{' '}
+                <strong>technical overhaul</strong>,{' '}
+                <strong>performance optimization</strong>,{' '}
+                <strong>process implementation</strong> (CI/CD, testing, code
+                review), <strong>technical debt management</strong>,{' '}
+                <strong>technology stack selection</strong>,{' '}
+                <strong>recruitment and team upskilling</strong>.
+              </p>
+              <p>
+                Our approach is pragmatic and results-oriented. We don't settle
+                for theoretical recommendations: we support you in the concrete
+                implementation of identified solutions, drawing on our hands-on
+                development experience.
+              </p>
+            </>
+          ))
+          .exhaustive()
+      }
     </Prose>
     <div class="mt-2 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      <SubService title="Audit technique" image={imgAudit}>
-        <p>
-          Analyse approfondie de votre <strong>code</strong>, de votre <strong
-            >architecture</strong
-          >, de vos <strong>processus</strong> et de votre <strong
-            >stack technologique</strong
-          >. Nous identifions les points d'amélioration et vous proposons un
-          plan d'action priorisé pour optimiser votre système.
-        </p>
+      <SubService
+        title={match(locale)
+          .with('fr', () => 'Audit technique')
+          .with('en', () => 'Technical audit')
+          .exhaustive()}
+        image={imgAudit}
+      >
+        {
+          match(locale)
+            .with('fr', () => (
+              <p>
+                Analyse approfondie de votre <strong>code</strong>, de votre{' '}
+                <strong>architecture</strong>, de vos <strong>processus</strong>{' '}
+                et de votre <strong>stack technologique</strong>. Nous
+                identifions les points d'amélioration et vous proposons un plan
+                d'action priorisé pour optimiser votre système.
+              </p>
+            ))
+            .with('en', () => (
+              <p>
+                In-depth analysis of your <strong>code</strong>, your{' '}
+                <strong>architecture</strong>, your <strong>processes</strong>,
+                and your <strong>technology stack</strong>. We identify areas
+                for improvement and propose a prioritized action plan to
+                optimize your system.
+              </p>
+            ))
+            .exhaustive()
+        }
       </SubService>
-      <SubService image={imgStrategy} title="Stratégie technique">
-        <p>
-          Définition de votre <strong>roadmap technique</strong>, choix des <strong
-            >technologies adaptées</strong
-          > à vos enjeux, arbitrages entre <strong>time-to-market</strong> et <strong
-            >qualité</strong
-          >, alignement de la tech avec vos objectifs business.
-        </p>
+      <SubService
+        image={imgStrategy}
+        title={match(locale)
+          .with('fr', () => 'Stratégie technique')
+          .with('en', () => 'Technical strategy')
+          .exhaustive()}
+      >
+        {
+          match(locale)
+            .with('fr', () => (
+              <p>
+                Définition de votre <strong>roadmap technique</strong>, choix
+                des <strong>technologies adaptées</strong> à vos enjeux,
+                arbitrages entre <strong>time-to-market</strong> et{' '}
+                <strong>qualité</strong>, alignement de la tech avec vos
+                objectifs business.
+              </p>
+            ))
+            .with('en', () => (
+              <p>
+                Definition of your <strong>technical roadmap</strong>, selection
+                of <strong>technologies suited</strong> to your challenges,
+                trade-offs between <strong>time-to-market</strong> and{' '}
+                <strong>quality</strong>, aligning technology with your business
+                objectives.
+              </p>
+            ))
+            .exhaustive()
+        }
       </SubService>
-      <SubService image={imgManagement} title="Management d'équipe">
-        <p>
-          Structuration et animation de vos <strong
-            >équipes de développement</strong
-          >, mise en place de <strong>rituels agiles</strong>, accompagnement au
-          <strong>recrutement</strong>, <strong
-            >montée en compétences des développeurs</strong
-          > et création d'une culture technique saine.
-        </p>
+      <SubService
+        image={imgManagement}
+        title={match(locale)
+          .with('fr', () => "Management d'équipe")
+          .with('en', () => 'Team management')
+          .exhaustive()}
+      >
+        {
+          match(locale)
+            .with('fr', () => (
+              <p>
+                Structuration et animation de vos{' '}
+                <strong>équipes de développement</strong>, mise en place de{' '}
+                <strong>rituels agiles</strong>, accompagnement au{' '}
+                <strong>recrutement</strong>,{' '}
+                <strong>montée en compétences des développeurs</strong> et
+                création d'une culture technique saine.
+              </p>
+            ))
+            .with('en', () => (
+              <p>
+                Structuring and leading your <strong>development teams</strong>,
+                implementing <strong>agile rituals</strong>, supporting{' '}
+                <strong>recruitment</strong>,{' '}
+                <strong>developer upskilling</strong>, and building a healthy
+                engineering culture.
+              </p>
+            ))
+            .exhaustive()
+        }
       </SubService>
     </div>
   </Container>
 
   <Container>
     <Prose>
-      <h2>Nos experts en accompagnement CTO</h2>
+      <h2>
+        {
+          match(locale)
+            .with('fr', () => 'Nos experts en accompagnement CTO')
+            .with('en', () => 'Our CTO support experts')
+            .exhaustive()
+        }
+      </h2>
     </Prose>
     <PeopleCarousel client:load people={people} locale={locale} />
   </Container>
 
   <Container>
     <Prose>
-      <h2>Notre approche de l'accompagnement CTO</h2>
-      <p>
-        Au BearStudio, nous ne sommes pas que des consultants : nous sommes des
-        <strong>praticiens</strong>. Nos CTO ont les mains dans le code au
-        quotidien sur nos projets, ce qui nous permet de vous apporter des
-        conseils concrets et réalistes, ancrés dans la pratique du développement
-        moderne.
-      </p>
-      <p>
-        Nous croyons en une approche <strong>pragmatique et itérative</strong>.
-        Plutôt que de grandes transformations théoriques, nous préférons des
-        améliorations progressives et mesurables qui apportent rapidement de la
-        valeur. Notre objectif est de vous rendre <strong>autonome</strong> sur vos
-        sujets techniques, pas de créer une dépendance.
-      </p>
-      <p>
-        Notre expertise couvre l'ensemble de l'écosystème <strong
-          >JavaScript/TypeScript</strong
-        > moderne (React, React Native, Node.js, TanStack, etc.) ainsi que les bonnes
-        pratiques de <strong>DevOps</strong>, d'<strong
-          >architecture logicielle</strong
-        > et de <strong>gestion de produit</strong>.
-      </p>
+      {
+        match(locale)
+          .with('fr', () => (
+            <>
+              <h2>Notre approche de l'accompagnement CTO</h2>
+              <p>
+                Au BearStudio, nous ne sommes pas que des consultants : nous
+                sommes des <strong>praticiens</strong>. Nos CTO ont les mains
+                dans le code au quotidien sur nos projets, ce qui nous permet de
+                vous apporter des conseils concrets et réalistes, ancrés dans la
+                pratique du développement moderne.
+              </p>
+              <p>
+                Nous croyons en une approche{' '}
+                <strong>pragmatique et itérative</strong>. Plutôt que de grandes
+                transformations théoriques, nous préférons des améliorations
+                progressives et mesurables qui apportent rapidement de la
+                valeur. Notre objectif est de vous rendre{' '}
+                <strong>autonome</strong> sur vos sujets techniques, pas de
+                créer une dépendance.
+              </p>
+              <p>
+                Notre expertise couvre l'ensemble de l'écosystème{' '}
+                <strong>JavaScript/TypeScript</strong> moderne (React, React
+                Native, Node.js, TanStack, etc.) ainsi que les bonnes pratiques
+                de <strong>DevOps</strong>, d'
+                <strong>architecture logicielle</strong> et de{' '}
+                <strong>gestion de produit</strong>.
+              </p>
+            </>
+          ))
+          .with('en', () => (
+            <>
+              <h2>Our approach to CTO support</h2>
+              <p>
+                At BearStudio, we're not just consultants: we're{' '}
+                <strong>practitioners</strong>. Our CTOs have their hands in the
+                code every day on our projects, which allows us to bring you
+                concrete, realistic advice grounded in modern development
+                practice.
+              </p>
+              <p>
+                We believe in a{' '}
+                <strong>pragmatic and iterative approach</strong>. Rather than
+                large theoretical transformations, we prefer progressive and
+                measurable improvements that quickly deliver value. Our goal is
+                to make you <strong>autonomous</strong> on your technical
+                topics, not to create dependency.
+              </p>
+              <p>
+                Our expertise covers the entire modern{' '}
+                <strong>JavaScript/TypeScript</strong> ecosystem (React, React
+                Native, Node.js, TanStack, etc.) as well as best practices in{' '}
+                <strong>DevOps</strong>, <strong>software architecture</strong>,
+                and <strong>product management</strong>.
+              </p>
+            </>
+          ))
+          .exhaustive()
+      }
     </Prose>
   </Container>
 
   <Container>
     <Prose>
-      <h2>Questions fréquentes sur l'accompagnement CTO</h2>
-      <p>
-        Retrouvez les réponses aux questions les plus courantes sur l'<strong
-          >accompagnement CTO</strong
-        >, nos interventions et notre méthodologie.
-      </p>
+      {
+        match(locale)
+          .with('fr', () => (
+            <>
+              <h2>Questions fréquentes sur l'accompagnement CTO</h2>
+              <p>
+                Retrouvez les réponses aux questions les plus courantes sur l'
+                <strong>accompagnement CTO</strong>, nos interventions et notre
+                méthodologie.
+              </p>
 
-      <div class="flex flex-col">
-        <Accordion question="Quand faire appel à un accompagnement CTO ?">
-          <p>
-            Plusieurs situations peuvent justifier un accompagnement CTO externe
-            :
-          </p>
-          <ul>
-            <li>
-              Vous êtes une <strong>startup en phase de lancement</strong> et vous
-              n'avez pas encore de CTO en interne
-            </li>
-            <li>
-              Votre <strong>CTO actuel est surchargé</strong> et a besoin d'un soutien
-              sur certains sujets
-            </li>
-            <li>
-              Vous souhaitez un <strong>regard externe</strong> sur vos choix techniques
-              ou votre architecture
-            </li>
-            <li>
-              Vous devez prendre des <strong
-                >décisions stratégiques importantes</strong
-              > (refonte, changement de stack, scaling)
-            </li>
-            <li>
-              Vous rencontrez des <strong>problèmes de performance</strong>, de
-              qualité de code ou de dette technique
-            </li>
-            <li>
-              Vous avez besoin d'<strong
-                >accompagnement sur le recrutement</strong
-              > ou la structuration de votre équipe tech
-            </li>
-          </ul>
-        </Accordion>
+              <div class="flex flex-col">
+                <Accordion question="Quand faire appel à un accompagnement CTO ?">
+                  <p>
+                    Plusieurs situations peuvent justifier un accompagnement CTO
+                    externe :
+                  </p>
+                  <ul>
+                    <li>
+                      Vous êtes une{' '}
+                      <strong>startup en phase de lancement</strong> et vous
+                      n'avez pas encore de CTO en interne
+                    </li>
+                    <li>
+                      Votre <strong>CTO actuel est surchargé</strong> et a
+                      besoin d'un soutien sur certains sujets
+                    </li>
+                    <li>
+                      Vous souhaitez un <strong>regard externe</strong> sur vos
+                      choix techniques ou votre architecture
+                    </li>
+                    <li>
+                      Vous devez prendre des{' '}
+                      <strong>décisions stratégiques importantes</strong>{' '}
+                      (refonte, changement de stack, scaling)
+                    </li>
+                    <li>
+                      Vous rencontrez des{' '}
+                      <strong>problèmes de performance</strong>, de qualité de
+                      code ou de dette technique
+                    </li>
+                    <li>
+                      Vous avez besoin d'
+                      <strong>accompagnement sur le recrutement</strong> ou la
+                      structuration de votre équipe tech
+                    </li>
+                  </ul>
+                </Accordion>
 
-        <Accordion
-          question="Quelle est la différence entre un CTO et un Lead Developer ?"
-        >
-          <p>
-            Le <strong>Lead Developer</strong> (ou Tech Lead) est avant tout un développeur
-            senior qui guide l'équipe sur les aspects techniques au quotidien. Il
-            est très impliqué dans le code et prend des décisions d'architecture
-            technique sur le produit.
-          </p>
-          <p>
-            Le <strong>CTO</strong> a une vision plus stratégique et transverse.
-            Il définit la direction technique de l'entreprise, fait le lien entre
-            la tech et le business, gère les aspects budgétaires, pilote le recrutement
-            et structure les processus. Il peut coder, mais ce n'est pas son activité
-            principale.
-          </p>
-          <p>
-            Dans les petites structures, ces rôles se chevauchent souvent. Un
-            accompagnement CTO peut d'ailleurs vous aider à clarifier ces rôles
-            et à structurer votre organisation tech.
-          </p>
-        </Accordion>
+                <Accordion question="Quelle est la différence entre un CTO et un Lead Developer ?">
+                  <p>
+                    Le <strong>Lead Developer</strong> (ou Tech Lead) est avant
+                    tout un développeur senior qui guide l'équipe sur les
+                    aspects techniques au quotidien. Il est très impliqué dans
+                    le code et prend des décisions d'architecture technique sur
+                    le produit.
+                  </p>
+                  <p>
+                    Le <strong>CTO</strong> a une vision plus stratégique et
+                    transverse. Il définit la direction technique de
+                    l'entreprise, fait le lien entre la tech et le business,
+                    gère les aspects budgétaires, pilote le recrutement et
+                    structure les processus. Il peut coder, mais ce n'est pas
+                    son activité principale.
+                  </p>
+                  <p>
+                    Dans les petites structures, ces rôles se chevauchent
+                    souvent. Un accompagnement CTO peut d'ailleurs vous aider à
+                    clarifier ces rôles et à structurer votre organisation tech.
+                  </p>
+                </Accordion>
 
-        <Accordion question="Comment se déroule un audit technique ?">
-          <p>
-            Un audit technique commence par une <strong
-              >phase de découverte</strong
-            > où nous échangeons avec vos équipes pour comprendre votre contexte,
-            vos enjeux et vos objectifs. Nous analysons ensuite votre code, votre
-            architecture, vos processus et vos outils.
-          </p>
-          <p>
-            Nous produisons un <strong>rapport d'audit détaillé</strong> qui identifie
-            les points forts, les axes d'amélioration et les risques techniques.
-            Chaque point est accompagné d'un <strong
-              >plan d'action concret</strong
-            > avec une estimation d'effort et une priorisation.
-          </p>
-          <p>
-            L'audit se conclut par une <strong>présentation interactive</strong>
-            où nous discutons des recommandations et ajustons les priorités en fonction
-            de vos contraintes. Nous pouvons ensuite vous accompagner dans la mise
-            en œuvre des améliorations identifiées.
-          </p>
-        </Accordion>
+                <Accordion question="Comment se déroule un audit technique ?">
+                  <p>
+                    Un audit technique commence par une{' '}
+                    <strong>phase de découverte</strong> où nous échangeons avec
+                    vos équipes pour comprendre votre contexte, vos enjeux et
+                    vos objectifs. Nous analysons ensuite votre code, votre
+                    architecture, vos processus et vos outils.
+                  </p>
+                  <p>
+                    Nous produisons un <strong>rapport d'audit détaillé</strong>{' '}
+                    qui identifie les points forts, les axes d'amélioration et
+                    les risques techniques. Chaque point est accompagné d'un{' '}
+                    <strong>plan d'action concret</strong> avec une estimation
+                    d'effort et une priorisation.
+                  </p>
+                  <p>
+                    L'audit se conclut par une{' '}
+                    <strong>présentation interactive</strong> où nous discutons
+                    des recommandations et ajustons les priorités en fonction de
+                    vos contraintes. Nous pouvons ensuite vous accompagner dans
+                    la mise en œuvre des améliorations identifiées.
+                  </p>
+                </Accordion>
 
-        <Accordion
-          question="Quelle est la durée d'un accompagnement CTO typique ?"
-        >
-          <p>
-            La durée dépend de vos besoins et de votre contexte. Un <strong
-              >audit technique ponctuel</strong
-            > peut se faire en quelques jours à deux semaines. Un accompagnement
-            pour une problématique spécifique (refonte, recrutement, etc.) peut durer
-            de quelques semaines à quelques mois.
-          </p>
-          <p>
-            Pour un <strong>CTO as a Service</strong>, nous recommandons
-            généralement un engagement d'au moins 3 à 6 mois pour pouvoir
-            réellement impacter votre organisation. L'intervention peut être à
-            temps partiel (1 à 2 jours par semaine) ou plus intensive selon les
-            besoins.
-          </p>
-          <p>
-            Nous privilégions les <strong>engagements flexibles</strong> qui peuvent
-            s'adapter à l'évolution de vos besoins plutôt que des contrats rigides
-            sur le long terme.
-          </p>
-        </Accordion>
+                <Accordion question="Quelle est la durée d'un accompagnement CTO typique ?">
+                  <p>
+                    La durée dépend de vos besoins et de votre contexte. Un{' '}
+                    <strong>audit technique ponctuel</strong> peut se faire en
+                    quelques jours à deux semaines. Un accompagnement pour une
+                    problématique spécifique (refonte, recrutement, etc.) peut
+                    durer de quelques semaines à quelques mois.
+                  </p>
+                  <p>
+                    Pour un <strong>CTO as a Service</strong>, nous recommandons
+                    généralement un engagement d'au moins 3 à 6 mois pour
+                    pouvoir réellement impacter votre organisation.
+                    L'intervention peut être à temps partiel (1 à 2 jours par
+                    semaine) ou plus intensive selon les besoins.
+                  </p>
+                  <p>
+                    Nous privilégions les <strong>engagements flexibles</strong>{' '}
+                    qui peuvent s'adapter à l'évolution de vos besoins plutôt
+                    que des contrats rigides sur le long terme.
+                  </p>
+                </Accordion>
 
-        <Accordion
-          question="Comment gérez-vous la confidentialité et la sécurité ?"
-        >
-          <p>
-            La <strong>confidentialité</strong> est au cœur de notre démarche. Nous
-            signons systématiquement des accords de confidentialité (NDA) avant toute
-            intervention et ne partageons jamais d'informations sur nos clients sans
-            leur accord explicite.
-          </p>
-          <p>
-            Concernant la <strong>sécurité</strong>, nous suivons les bonnes
-            pratiques de l'industrie : accès sécurisés aux systèmes (MFA, VPN si
-            nécessaire), gestion stricte des accès et des credentials, respect
-            du RGPD pour les données personnelles.
-          </p>
-          <p>
-            Si votre contexte nécessite des mesures de sécurité spécifiques,
-            nous nous adaptons à vos exigences et pouvons intervenir dans des
-            environnements hautement sécurisés.
-          </p>
-        </Accordion>
+                <Accordion question="Comment gérez-vous la confidentialité et la sécurité ?">
+                  <p>
+                    La <strong>confidentialité</strong> est au cœur de notre
+                    démarche. Nous signons systématiquement des accords de
+                    confidentialité (NDA) avant toute intervention et ne
+                    partageons jamais d'informations sur nos clients sans leur
+                    accord explicite.
+                  </p>
+                  <p>
+                    Concernant la <strong>sécurité</strong>, nous suivons les
+                    bonnes pratiques de l'industrie : accès sécurisés aux
+                    systèmes (MFA, VPN si nécessaire), gestion stricte des accès
+                    et des credentials, respect du RGPD pour les données
+                    personnelles.
+                  </p>
+                  <p>
+                    Si votre contexte nécessite des mesures de sécurité
+                    spécifiques, nous nous adaptons à vos exigences et pouvons
+                    intervenir dans des environnements hautement sécurisés.
+                  </p>
+                </Accordion>
 
-        <Accordion
-          question="Pourquoi le BearStudio pour votre accompagnement CTO ?"
-        >
-          <p>
-            Au BearStudio, nous ne sommes pas que des consultants : nous sommes
-            des <strong>builders</strong>. Nous développons nous-mêmes des
-            produits, nous maintenons des projets open source, nous sommes au
-            contact quotidien du code et des problématiques concrètes de
-            développement.
-          </p>
+                <Accordion question="Pourquoi le BearStudio pour votre accompagnement CTO ?">
+                  <p>
+                    Au BearStudio, nous ne sommes pas que des consultants : nous
+                    sommes des <strong>builders</strong>. Nous développons
+                    nous-mêmes des produits, nous maintenons des projets open
+                    source, nous sommes au contact quotidien du code et des
+                    problématiques concrètes de développement.
+                  </p>
+                  <p>
+                    Cette <strong>expérience terrain</strong> nous permet de
+                    vous apporter des conseils pragmatiques, testés et éprouvés,
+                    plutôt que des recommandations théoriques déconnectées de la
+                    réalité du développement.
+                  </p>
+                  <p>
+                    Nous avons accompagné des startups en phase d'amorçage comme
+                    des scaleups et des grands comptes, sur des problématiques
+                    très variées. Cette diversité d'expérience nous permet de
+                    nous adapter rapidement à votre contexte et de vous apporter
+                    des solutions pertinentes.
+                  </p>
+                  <p>
+                    Notre approche est{' '}
+                    <strong>collaborative et transparente</strong>. Nous
+                    travaillons avec vos équipes, pas à leur place. Notre
+                    objectif est de vous transmettre nos connaissances et de
+                    vous rendre autonome sur vos enjeux techniques.
+                  </p>
+                  <p>
+                    Enfin, notre expertise couvre l'ensemble du spectre du
+                    développement web et mobile moderne. Que vous travailliez
+                    avec React, React Native, Node.js ou d'autres technologies,
+                    nous avons l'expertise pour vous guider efficacement.
+                  </p>
+                </Accordion>
 
-          <p>
-            Cette <strong>expérience terrain</strong> nous permet de vous apporter
-            des conseils pragmatiques, testés et éprouvés, plutôt que des recommandations
-            théoriques déconnectées de la réalité du développement.
-          </p>
+                <Accordion question="Proposez-vous de l'accompagnement pour des technologies spécifiques ?">
+                  <p>
+                    Notre expertise principale se concentre sur l'écosystème{' '}
+                    <strong>JavaScript/TypeScript</strong> : React, React
+                    Native, Node.js, Next.js, TanStack Start, Astro, et
+                    l'ensemble des technologies associées (TailwindCSS, Prisma,
+                    tRPC, etc.).
+                  </p>
+                  <p>
+                    Nous maîtrisons également les aspects{' '}
+                    <strong>DevOps</strong> modernes : CI/CD, containerisation
+                    (Docker), déploiement cloud (Vercel, AWS, etc.), monitoring
+                    et performance.
+                  </p>
+                  <p>
+                    Si votre stack technique sort de notre périmètre d'expertise
+                    principal, nous serons transparents avec vous et pourrons
+                    vous orienter vers les bons partenaires. Nous préférons
+                    reconnaître nos limites plutôt que de vous accompagner sur
+                    des sujets que nous ne maîtrisons pas parfaitement.
+                  </p>
+                </Accordion>
+              </div>
+            </>
+          ))
+          .with('en', () => (
+            <>
+              <h2>Frequently asked questions about CTO support</h2>
+              <p>
+                Find answers to the most common questions about{' '}
+                <strong>CTO support</strong>, our services, and our methodology.
+              </p>
 
-          <p>
-            Nous avons accompagné des startups en phase d'amorçage comme des
-            scaleups et des grands comptes, sur des problématiques très variées.
-            Cette diversité d'expérience nous permet de nous adapter rapidement
-            à votre contexte et de vous apporter des solutions pertinentes.
-          </p>
+              <div class="flex flex-col">
+                <Accordion question="When should you seek CTO support?">
+                  <p>Several situations may warrant external CTO support:</p>
+                  <ul>
+                    <li>
+                      You're an <strong>early-stage startup</strong> and don't
+                      yet have an in-house CTO
+                    </li>
+                    <li>
+                      Your <strong>current CTO is overloaded</strong> and needs
+                      support on certain topics
+                    </li>
+                    <li>
+                      You want an <strong>external perspective</strong> on your
+                      technical choices or architecture
+                    </li>
+                    <li>
+                      You need to make{' '}
+                      <strong>important strategic decisions</strong> (overhaul,
+                      stack change, scaling)
+                    </li>
+                    <li>
+                      You're facing <strong>performance issues</strong>, code
+                      quality problems, or technical debt
+                    </li>
+                    <li>
+                      You need <strong>support with recruitment</strong> or
+                      structuring your tech team
+                    </li>
+                  </ul>
+                </Accordion>
 
-          <p>
-            Notre approche est <strong>collaborative et transparente</strong>.
-            Nous travaillons avec vos équipes, pas à leur place. Notre objectif
-            est de vous transmettre nos connaissances et de vous rendre autonome
-            sur vos enjeux techniques.
-          </p>
+                <Accordion question="What is the difference between a CTO and a Lead Developer?">
+                  <p>
+                    A <strong>Lead Developer</strong> (or Tech Lead) is first
+                    and foremost a senior developer who guides the team on
+                    day-to-day technical matters. They are deeply involved in
+                    the code and make technical architecture decisions on the
+                    product.
+                  </p>
+                  <p>
+                    A <strong>CTO</strong> has a more strategic and
+                    cross-functional vision. They define the company's technical
+                    direction, bridge the gap between tech and business, manage
+                    budgets, lead recruitment, and structure processes. They may
+                    code, but it's not their primary activity.
+                  </p>
+                  <p>
+                    In smaller organizations, these roles often overlap. CTO
+                    support can actually help you clarify these roles and
+                    structure your tech organization.
+                  </p>
+                </Accordion>
 
-          <p>
-            Enfin, notre expertise couvre l'ensemble du spectre du développement
-            web et mobile moderne. Que vous travailliez avec React, React
-            Native, Node.js ou d'autres technologies, nous avons l'expertise
-            pour vous guider efficacement.
-          </p>
-        </Accordion>
+                <Accordion question="How does a technical audit work?">
+                  <p>
+                    A technical audit begins with a{' '}
+                    <strong>discovery phase</strong> where we exchange with your
+                    teams to understand your context, challenges, and
+                    objectives. We then analyze your code, architecture,
+                    processes, and tools.
+                  </p>
+                  <p>
+                    We produce a <strong>detailed audit report</strong> that
+                    identifies strengths, areas for improvement, and technical
+                    risks. Each point comes with a{' '}
+                    <strong>concrete action plan</strong> with effort estimates
+                    and prioritization.
+                  </p>
+                  <p>
+                    The audit concludes with an{' '}
+                    <strong>interactive presentation</strong> where we discuss
+                    recommendations and adjust priorities based on your
+                    constraints. We can then support you in implementing the
+                    identified improvements.
+                  </p>
+                </Accordion>
 
-        <Accordion
-          question="Proposez-vous de l'accompagnement pour des technologies spécifiques ?"
-        >
-          <p>
-            Notre expertise principale se concentre sur l'écosystème <strong
-              >JavaScript/TypeScript</strong
-            > : React, React Native, Node.js, Next.js, TanStack Start, Astro, et
-            l'ensemble des technologies associées (TailwindCSS, Prisma, tRPC, etc.).
-          </p>
-          <p>
-            Nous maîtrisons également les aspects <strong>DevOps</strong> modernes
-            : CI/CD, containerisation (Docker), déploiement cloud (Vercel, AWS, etc.),
-            monitoring et performance.
-          </p>
-          <p>
-            Si votre stack technique sort de notre périmètre d'expertise
-            principal, nous serons transparents avec vous et pourrons vous
-            orienter vers les bons partenaires. Nous préférons reconnaître nos
-            limites plutôt que de vous accompagner sur des sujets que nous ne
-            maîtrisons pas parfaitement.
-          </p>
-        </Accordion>
-      </div>
+                <Accordion question="What is the typical duration of CTO support?">
+                  <p>
+                    The duration depends on your needs and context. A{' '}
+                    <strong>one-off technical audit</strong> can be done in a
+                    few days to two weeks. Support for a specific issue
+                    (overhaul, recruitment, etc.) can last from a few weeks to a
+                    few months.
+                  </p>
+                  <p>
+                    For <strong>CTO as a Service</strong>, we generally
+                    recommend a commitment of at least 3 to 6 months to truly
+                    impact your organization. The engagement can be part-time (1
+                    to 2 days per week) or more intensive depending on needs.
+                  </p>
+                  <p>
+                    We favor <strong>flexible commitments</strong> that can
+                    adapt to your evolving needs rather than rigid long-term
+                    contracts.
+                  </p>
+                </Accordion>
+
+                <Accordion question="How do you handle confidentiality and security?">
+                  <p>
+                    <strong>Confidentiality</strong> is at the core of our
+                    approach. We systematically sign non-disclosure agreements
+                    (NDAs) before any engagement and never share client
+                    information without their explicit consent.
+                  </p>
+                  <p>
+                    Regarding <strong>security</strong>, we follow industry best
+                    practices: secure system access (MFA, VPN if needed), strict
+                    access and credential management, GDPR compliance for
+                    personal data.
+                  </p>
+                  <p>
+                    If your context requires specific security measures, we
+                    adapt to your requirements and can work within highly
+                    secured environments.
+                  </p>
+                </Accordion>
+
+                <Accordion question="Why choose BearStudio for your CTO support?">
+                  <p>
+                    At BearStudio, we're not just consultants: we're{' '}
+                    <strong>builders</strong>. We develop our own products, we
+                    maintain open source projects, we're in daily contact with
+                    code and concrete development challenges.
+                  </p>
+                  <p>
+                    This <strong>hands-on experience</strong> allows us to bring
+                    you pragmatic, tested, and proven advice, rather than
+                    theoretical recommendations disconnected from the reality of
+                    development.
+                  </p>
+                  <p>
+                    We have supported early-stage startups as well as scaleups
+                    and large enterprises, on a wide variety of challenges. This
+                    diversity of experience allows us to quickly adapt to your
+                    context and bring you relevant solutions.
+                  </p>
+                  <p>
+                    Our approach is{' '}
+                    <strong>collaborative and transparent</strong>. We work with
+                    your teams, not in their place. Our goal is to transfer our
+                    knowledge and make you autonomous on your technical
+                    challenges.
+                  </p>
+                  <p>
+                    Finally, our expertise covers the full spectrum of modern
+                    web and mobile development. Whether you work with React,
+                    React Native, Node.js, or other technologies, we have the
+                    expertise to guide you effectively.
+                  </p>
+                </Accordion>
+
+                <Accordion question="Do you offer support for specific technologies?">
+                  <p>
+                    Our core expertise focuses on the{' '}
+                    <strong>JavaScript/TypeScript</strong> ecosystem: React,
+                    React Native, Node.js, Next.js, TanStack Start, Astro, and
+                    all associated technologies (TailwindCSS, Prisma, tRPC,
+                    etc.).
+                  </p>
+                  <p>
+                    We also master modern <strong>DevOps</strong> practices:
+                    CI/CD, containerization (Docker), cloud deployment (Vercel,
+                    AWS, etc.), monitoring, and performance.
+                  </p>
+                  <p>
+                    If your tech stack falls outside our primary area of
+                    expertise, we'll be transparent with you and can point you
+                    to the right partners. We prefer to acknowledge our limits
+                    rather than support you on topics we don't master perfectly.
+                  </p>
+                </Accordion>
+              </div>
+            </>
+          ))
+          .exhaustive()
+      }
     </Prose>
   </Container>
 </MainLayout>


### PR DESCRIPTION
Add `match(locale)` pattern to render both French and English content on the CTO support service page. Translates all major sections including introduction, contact card, service descriptions, expert section, approach, and all 7 FAQ items.

The English page at `/en/services/cto-support` already re-exports from the French page, so this change automatically enables both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)