### PR TITLE
feat: add translations for home work with us section

### DIFF
--- a/src/i18n/en/home.json
+++ b/src/i18n/en/home.json
@@ -72,5 +72,29 @@
       "description": "It's great to work at BearStudio: we form a complementary team that puts its good mood at the service of your projects!",
       "hashtag": "#TrollInside"
     }
+  },
+  "workWithUs": {
+    "title": "Work with BearStudio",
+    "description": "A full range of services to support the development of your digital project.",
+    "design": {
+      "title": "Application design",
+      "description1": "We design <strong>modern and intuitive user interfaces</strong> that put the user experience at the heart of every project.",
+      "description2": "Our UX/UI approach ensures <strong>aesthetic, accessible, and ergonomic</strong> applications to maximize user engagement."
+    },
+    "development": {
+      "title": "Web and mobile application development",
+      "description1": "We develop <strong>performant and scalable applications</strong> using the technologies best suited to your needs.",
+      "description2": "From web to mobile, we create <strong>robust and maintainable</strong> solutions that support the growth of your business."
+    },
+    "boost": {
+      "title": "Boost your projects",
+      "description1": "We step in to <strong>reinforce your teams</strong>, accelerate your developments, and bring our technical expertise.",
+      "description2": "Our flexible support helps <strong>unblock your projects</strong> and reach your goals in the best timeframes."
+    },
+    "ai": {
+      "title": "AI Ready",
+      "description1": "We integrate <strong>artificial intelligence</strong> into your applications to automate and optimize your business processes.",
+      "description2": "Our AI expertise allows you to <strong>leverage the latest advances</strong> in technology to stay competitive."
+    }
   }
 }

--- a/src/i18n/fr/home.json
+++ b/src/i18n/fr/home.json
@@ -72,5 +72,29 @@
       "description": "Il fait bon travailler au BearStudio : nous formons une équipe complémentaire qui met sa bonne humeur au service de vos projets !",
       "hashtag": "#TrollInside"
     }
+  },
+  "workWithUs": {
+    "title": "Travailler avec le bearstudio",
+    "description": "Tout un panel d'offres pour assurer le développement de votre projet numérique.",
+    "design": {
+      "title": "Design de vos applications",
+      "description1": "Nous concevons des <strong>interfaces utilisateur modernes et intuitives</strong> qui placent l'expérience utilisateur au coeur de chaque projet.",
+      "description2": "Notre approche UX/UI garantit des applications <strong>esthétiques, accessibles et ergonomiques</strong> pour maximiser l'engagement de vos utilisateurs."
+    },
+    "development": {
+      "title": "Développement d'application web et mobile",
+      "description1": "Nous développons des <strong>applications performantes et évolutives</strong> en utilisant les technologies les plus adaptées à vos besoins.",
+      "description2": "Du web au mobile, nous créons des solutions <strong>robustes et maintenables</strong> qui accompagnent la croissance de votre activité."
+    },
+    "boost": {
+      "title": "Booster vos projets",
+      "description1": "Nous intervenons en <strong>renfort de vos équipes</strong> pour accélérer vos développements et apporter notre expertise technique.",
+      "description2": "Notre accompagnement flexible permet de <strong>débloquer vos projets</strong> et d'atteindre vos objectifs dans les meilleurs délais."
+    },
+    "ai": {
+      "title": "AI Ready",
+      "description1": "Nous intégrons l'<strong>intelligence artificielle</strong> dans vos applications pour automatiser et optimiser vos processus métier.",
+      "description2": "Notre expertise IA vous permet de <strong>tirer parti des dernières avancées</strong> technologiques pour rester compétitif."
+    }
   }
 }

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -534,17 +534,16 @@ const latestPosts = await Promise.all(
       </Container>
     </SectionScratched>
 
-    {/* Work with use */}
+    {/* Work with us */}
     <Container class="sm:flex-row sm:gap-8">
       <div class="flex flex-1 flex-col gap-2">
         <h2
           class="font-heading text-2xl font-bold text-balance md:max-w-[20ch]"
         >
-          Travailler avec le bearstudio
+          {t('home.workWithUs.title')}
         </h2>
         <p class="max-w-[70ch] text-sm text-balance">
-          Tout un panel d’offres pour assurer le développement de votre projet
-          numérique.
+          {t('home.workWithUs.description')}
         </p>
         <ContactCta locale={locale} />
       </div>
@@ -554,21 +553,12 @@ const latestPosts = await Promise.all(
             <a
               href={getLink('/fr/prestations/ux-design', locale, {})}
               class="text-foreground! no-underline hover:underline"
-              >Design de vos applications</a
+              >{t('home.workWithUs.design.title')}</a
             >
           </h3>
           <>
-            <p>
-              Nous concevons des <strong
-                >interfaces utilisateur modernes et intuitives</strong
-              >{' '}
-              qui placent l'expérience utilisateur au coeur de chaque projet.
-            </p>
-            <p>
-              Notre approche UX/UI garantit des applications{' '}
-              <strong>esthétiques, accessibles et ergonomiques</strong> pour maximiser
-              l'engagement de vos utilisateurs.
-            </p>
+            <p set:html={t('home.workWithUs.design.description1')} />
+            <p set:html={t('home.workWithUs.design.description2')} />
           </>
         </Prose>
         <Prose class="prose-sm prose-p:my-0.5 flex flex-col">
@@ -576,21 +566,12 @@ const latestPosts = await Promise.all(
             <a
               href={getLink('/fr/prestations/developpement-web', locale, {})}
               class="text-foreground! no-underline hover:underline"
-              >Développement d'application web et mobile</a
+              >{t('home.workWithUs.development.title')}</a
             >
           </h3>
           <>
-            <p>
-              Nous développons des <strong
-                >applications performantes et évolutives</strong
-              >{' '}
-              en utilisant les technologies les plus adaptées à vos besoins.
-            </p>
-            <p>
-              Du web au mobile, nous créons des solutions{' '}
-              <strong>robustes et maintenables</strong> qui accompagnent la croissance
-              de votre activité.
-            </p>
+            <p set:html={t('home.workWithUs.development.description1')} />
+            <p set:html={t('home.workWithUs.development.description2')} />
           </>
         </Prose>
         <Prose class="prose-sm prose-p:my-0.5 flex flex-col">
@@ -598,33 +579,19 @@ const latestPosts = await Promise.all(
             <a
               href={getLink('/fr/prestations/boost-projet', locale, {})}
               class="text-foreground! no-underline hover:underline"
-              >Booster vos projets</a
+              >{t('home.workWithUs.boost.title')}</a
             >
           </h3>
           <>
-            <p>
-              Nous intervenons en <strong>renfort de vos équipes</strong> pour accélérer
-              vos développements et apporter notre expertise technique.
-            </p>
-            <p>
-              Notre accompagnement flexible permet de{' '}
-              <strong>débloquer vos projets</strong> et d'atteindre vos objectifs
-              dans les meilleurs délais.
-            </p>
+            <p set:html={t('home.workWithUs.boost.description1')} />
+            <p set:html={t('home.workWithUs.boost.description2')} />
           </>
         </Prose>
         <Prose class="prose-sm prose-p:my-0.5 flex flex-col">
-          <h3>AI Ready</h3>
+          <h3>{t('home.workWithUs.ai.title')}</h3>
           <>
-            <p>
-              Nous intégrons l'<strong>intelligence artificielle</strong> dans vos
-              applications pour automatiser et optimiser vos processus métier.
-            </p>
-            <p>
-              Notre expertise IA vous permet de{' '}
-              <strong>tirer parti des dernières avancées</strong> technologiques
-              pour rester compétitif.
-            </p>
+            <p set:html={t('home.workWithUs.ai.description1')} />
+            <p set:html={t('home.workWithUs.ai.description2')} />
           </>
         </Prose>
       </div>


### PR DESCRIPTION
## Summary

Extract hardcoded French text from the home page "Work with us" section and move it to the translation system. This adds new translation keys for design, development, boost, and AI services with both French and English translations.

## Changes

- Added `home.workWithUs` translation keys to both French and English translation files
- Replaced all hardcoded text in the "Work with us" section with `t()` calls
- Used `set:html` directive to preserve `<strong>` formatting in descriptions
- Fixed typo in comment: "Work with use" → "Work with us"

## Testing

The build completes successfully with no errors. All linters pass (astro check, eslint, typescript).