### PR TITLE
feat: add skip-to-content accessibility link

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -24,5 +24,6 @@
     "description": "Founded in 2016, BearStudio is a R&D project support studio: custom web and mobile development, feasibility studies and technological audits, nothing scares us!",
     "copyright": "© All rights reserved"
   },
-  "contactCta": "Contact us"
+  "contactCta": "Contact us",
+  "skipToContent": "Skip to content"
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -24,5 +24,6 @@
     "description": "Créé en 2016, le BearStudio est un studio d'accompagnement de projets en R&D : développement sur-mesure Web et mobile, études de faisabilité et audit technologique, rien ne nous effraie !",
     "copyright": "© Tous droits réservés"
   },
-  "contactCta": "Contactez-nous"
+  "contactCta": "Contactez-nous",
+  "skipToContent": "Aller au contenu"
 }

--- a/src/layouts/main-layout.astro
+++ b/src/layouts/main-layout.astro
@@ -21,7 +21,7 @@ import RootLayout from '@/layouts/root-layout.astro';
     pathname={Astro.url.pathname}
   />
 
-  <main class="flex flex-1 flex-col">
+  <main id="main-content" class="flex flex-1 flex-col">
     <slot />
   </main>
   <Footer />

--- a/src/layouts/root-layout.astro
+++ b/src/layouts/root-layout.astro
@@ -94,6 +94,12 @@ dayjs.locale(Astro.currentLocale);
   <body
     class="bg-background text-foreground flex min-h-svh flex-col overflow-x-hidden overflow-y-scroll"
   >
+    <a
+      href="#main-content"
+      class="focus:bg-background focus:ring-ring sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:ring-2 focus:outline-none"
+    >
+      {t('common.skipToContent')}
+    </a>
     <EnvHint />
     <div class="flex flex-1 flex-col overflow-x-hidden">
       <slot />


### PR DESCRIPTION
## Summary

Add a keyboard-navigable skip link that allows users to jump directly to the main content, improving accessibility for keyboard and screen reader users. The link appears at the top of the page and is visually hidden by default, becoming visible on focus.

## Changes

- Added `skipToContent` translation keys in both English and French
- Added skip-to-content link as first element in `<body>`
- Added `id="main-content"` to the main content area for the skip link target

✅ All tests and linting passed