### PR TITLE
fix linkedin link and remove 'junior' from post

### DIFF
--- a/src/content/people/dylan-flandrin/en.md
+++ b/src/content/people/dylan-flandrin/en.md
@@ -1,10 +1,10 @@
 ---
 name: 'Dylan Flandrin'
 picture: './trylan.png'
-job: 'Junior Front-End Developer'
+job: 'Front-End Developer'
 socials:
   - type: 'linkedin'
-    href: 'https://www.linkedin.com/in/dylanfland/'
+    href: 'https://www.linkedin.com/in/dylan-fland/'
 status: 'current'
 hidden: false
 order: 95

--- a/src/content/people/dylan-flandrin/fr.md
+++ b/src/content/people/dylan-flandrin/fr.md
@@ -1,10 +1,10 @@
 ---
 name: 'Dylan Flandrin'
 picture: './trylan.png'
-job: 'Junior Front-End Developer'
+job: 'Front-End Developer'
 socials:
   - type: 'linkedin'
-    href: 'https://www.linkedin.com/in/dylanfland/'
+    href: 'https://www.linkedin.com/in/dylan-fland/'
 status: 'current'
 hidden: false
 order: 95


### PR DESCRIPTION
## Description

- Removed "Junior" from the title: less impactful commercially and not relevant as a first impression
- Fixed LinkedIn link: URL was pointing to the wrong profile