### PR TITLE
feat: add llms.txt support for LLM-friendly content discovery

### DIFF
--- a/src/components/seo/index.astro
+++ b/src/components/seo/index.astro
@@ -29,6 +29,7 @@ interface Props
   url?: NonNullable<ComponentProps<typeof SEO>['openGraph']>['basic']['url'];
   alternates: Required<Record<Locale, string | null>> | null;
   breadcrumb: Array<BreadcrumbEntry> | null;
+  markdownUrl?: string;
 }
 const {
   title,
@@ -41,6 +42,7 @@ const {
   alternates,
   openGraph,
   breadcrumb,
+  markdownUrl,
 } = Astro.props;
 
 const locale = parseAstroLocale(Astro.currentLocale);
@@ -101,6 +103,12 @@ const languageAlternates = isNonNullish(alternates)
     site: '@_BearStudio',
   }}
 />
+
+{
+  markdownUrl && (
+    <link rel="alternate" type="text/markdown" href={markdownUrl} />
+  )
+}
 
 {
   !!breadcrumb?.length && (

--- a/src/i18n/routes-map.ts
+++ b/src/i18n/routes-map.ts
@@ -33,6 +33,7 @@ export const ROUTE_MAPPINGS = {
     en: '/en/contact/application-process-bearstudio',
   },
   '/fr/blog/rss.xml': { en: '/en/blog/rss.xml' },
+  '/fr/blog/articles/:id.md': { en: '/en/blog/posts/:id.md' },
 } as const satisfies Record<
   DefaultLocaleRoutePaths,
   Record<LocalesWithoutDefault, RoutePaths | null>

--- a/src/lib/llms.ts
+++ b/src/lib/llms.ts
@@ -1,0 +1,26 @@
+import type { PostWithComputed } from '@/lib/posts';
+
+export function postToMarkdown(post: PostWithComputed): string {
+  const lines: Array<string> = [
+    `# ${post.data.title}`,
+    '',
+    ...(post.data.metaDescription
+      ? [`> ${post.data.metaDescription}`, '']
+      : []),
+    `Date: ${post.data.date.toISOString().split('T')[0]}`,
+  ];
+
+  if (post.data._computed.authors.length) {
+    lines.push(
+      `Authors: ${post.data._computed.authors.map((a) => a.data.name).join(', ')}`
+    );
+  }
+
+  if (post.data.tags?.length) {
+    lines.push(`Tags: ${post.data.tags.join(', ')}`);
+  }
+
+  lines.push('', '---', '', post.body ?? '');
+
+  return lines.join('\n');
+}

--- a/src/pages/en/blog/posts/[id].md.ts
+++ b/src/pages/en/blog/posts/[id].md.ts
@@ -1,0 +1,11 @@
+import type { GetStaticPaths, GetStaticPathsOptions } from 'astro';
+
+import { generateStaticPaths } from '@/pages/fr/blog/articles/[id].md';
+
+export const getStaticPaths: GetStaticPaths = async (
+  params: GetStaticPathsOptions
+) => {
+  return generateStaticPaths({ ...params, locale: 'en' });
+};
+
+export { GET } from '@/pages/fr/blog/articles/[id].md';

--- a/src/pages/fr/blog/articles/[id].md.ts
+++ b/src/pages/fr/blog/articles/[id].md.ts
@@ -1,0 +1,34 @@
+import type { APIRoute, GetStaticPaths, GetStaticPathsOptions } from 'astro';
+
+import { postToMarkdown } from '@/lib/llms';
+import { getPostsCollection } from '@/lib/posts';
+import type { Locale } from '@/i18n/utils';
+
+export async function generateStaticPaths(
+  params: {
+    locale: Locale;
+  } & GetStaticPathsOptions
+) {
+  const posts = await getPostsCollection({ locale: params.locale });
+
+  return posts.map((post) => ({
+    params: { id: post.data._computed.slug },
+    props: { post },
+  }));
+}
+
+export const getStaticPaths: GetStaticPaths = async (
+  params: GetStaticPathsOptions
+) => {
+  return generateStaticPaths({ ...params, locale: 'fr' });
+};
+
+export const GET: APIRoute = function get({ props }) {
+  const { post } = props;
+
+  return new Response(postToMarkdown(post), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/src/pages/fr/blog/articles/[id]/index.astro
+++ b/src/pages/fr/blog/articles/[id]/index.astro
@@ -100,6 +100,7 @@ const [slugFr, slugEn] = await Promise.all([
         : null,
     }}
     breadcrumb={breadcrumb}
+    markdownUrl={`${Astro.url.pathname}.md`}
   />
   <Schema
     slot="ld+json"

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,105 @@
+import type { APIRoute } from 'astro';
+
+import { getLink } from '@/lib/link';
+import { getPeopleCollection } from '@/lib/people';
+import { getPostsCollection } from '@/lib/posts';
+import { getSiteUrl } from '@/lib/site/get-site-url';
+import { getTranslationFn } from '@/i18n/utils';
+
+function stripHtml(str: string): string {
+  return str.replace(/<[^>]*>/g, '');
+}
+
+export const GET: APIRoute = async function get() {
+  const siteUrl = getSiteUrl();
+  const tFr = getTranslationFn('fr');
+  const tEn = getTranslationFn('en');
+
+  const postsFr = await getPostsCollection({ locale: 'fr' });
+  const postsEn = await getPostsCollection({ locale: 'en' });
+  const peopleFr = await getPeopleCollection({
+    locale: 'fr',
+    status: 'current',
+  });
+
+  const sections: Array<string> = [
+    '# BearStudio',
+    '',
+    '> BearStudio is a French development studio based in Normandy, specializing in UX design, web and mobile development, and AI integration. We support digital project founders from idea to production.',
+    '',
+    '## About (FR)',
+    '',
+    tFr('home.metadata.description'),
+    '',
+    tFr('home.description'),
+    '',
+    '## About (EN)',
+    '',
+    tEn('home.metadata.description'),
+    '',
+    tEn('home.description'),
+    '',
+    '## Services',
+    '',
+    `### ${tFr('home.workWithUs.design.title')}`,
+    '',
+    stripHtml(tFr('home.workWithUs.design.description1')),
+    stripHtml(tFr('home.workWithUs.design.description2')),
+    '',
+    `### ${tFr('home.workWithUs.development.title')}`,
+    '',
+    stripHtml(tFr('home.workWithUs.development.description1')),
+    stripHtml(tFr('home.workWithUs.development.description2')),
+    '',
+    `### ${tFr('home.workWithUs.boost.title')}`,
+    '',
+    stripHtml(tFr('home.workWithUs.boost.description1')),
+    stripHtml(tFr('home.workWithUs.boost.description2')),
+    '',
+    `### ${tFr('home.workWithUs.ai.title')}`,
+    '',
+    stripHtml(tFr('home.workWithUs.ai.description1')),
+    stripHtml(tFr('home.workWithUs.ai.description2')),
+    '',
+    '## Team',
+    '',
+    ...peopleFr.flatMap((person) => [
+      `### ${person.data.name}`,
+      '',
+      ...(person.data.job ? [person.data.job, ''] : []),
+      ...(person.body ? [person.body, ''] : []),
+    ]),
+    '## Blog Articles (FR)',
+    '',
+    ...postsFr.flatMap((post) => [
+      `### ${post.data.title}`,
+      '',
+      `URL: ${siteUrl}${getLink('/fr/blog/articles/:id', 'fr', { id: post.data._computed.slug })}`,
+      `Date: ${post.data.date.toISOString().split('T')[0]}`,
+      '',
+      post.body ?? '',
+      '',
+      '---',
+      '',
+    ]),
+    '## Blog Articles (EN)',
+    '',
+    ...postsEn.flatMap((post) => [
+      `### ${post.data.title}`,
+      '',
+      `URL: ${siteUrl}${getLink('/fr/blog/articles/:id', 'en', { id: post.data._computed.slug })}`,
+      `Date: ${post.data.date.toISOString().split('T')[0]}`,
+      '',
+      post.body ?? '',
+      '',
+      '---',
+      '',
+    ]),
+  ];
+
+  return new Response(sections.join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,64 @@
+import type { APIRoute } from 'astro';
+
+import { getLink } from '@/lib/link';
+import { getPostsCollection } from '@/lib/posts';
+import { getSiteUrl } from '@/lib/site/get-site-url';
+
+export const GET: APIRoute = async function get() {
+  const siteUrl = getSiteUrl();
+  const recentPostsFr = await getPostsCollection({ locale: 'fr', limit: 10 });
+  const recentPostsEn = await getPostsCollection({ locale: 'en', limit: 5 });
+
+  const lines: Array<string> = [
+    '# BearStudio',
+    '',
+    '> BearStudio is a French development studio based in Normandy, specializing in UX design, web and mobile development, and AI integration. We support digital project founders from idea to production.',
+    '',
+    '## Site Navigation',
+    '',
+    `- [Accueil (FR)](${siteUrl}/fr): Page d'accueil française`,
+    `- [Home (EN)](${siteUrl}/en): English home page`,
+    `- [Prestations](${siteUrl}${getLink('/fr/prestations', 'fr', {})}): Nos prestations`,
+    `- [Services](${siteUrl}${getLink('/fr/prestations', 'en', {})}): Our services`,
+    `- [Équipe](${siteUrl}${getLink('/fr/equipe', 'fr', {})}): Notre équipe`,
+    `- [Team](${siteUrl}${getLink('/fr/equipe', 'en', {})}): Our team`,
+    `- [Blog (FR)](${siteUrl}${getLink('/fr/blog', 'fr', {})}): Articles de blog en français`,
+    `- [Blog (EN)](${siteUrl}${getLink('/fr/blog', 'en', {})}): Blog posts in English`,
+    `- [Contact](${siteUrl}${getLink('/fr/contact', 'fr', {})}): Nous contacter`,
+    '',
+    '## Services',
+    '',
+    `- [UX/UI Design](${siteUrl}${getLink('/fr/prestations/ux-design', 'fr', {})}): Conception d'expériences utilisateur modernes et intuitives`,
+    `- [Développement Web](${siteUrl}${getLink('/fr/prestations/developpement-web', 'fr', {})}): Applications web performantes et évolutives`,
+    `- [Développement Mobile](${siteUrl}${getLink('/fr/prestations/developpement-mobile', 'fr', {})}): Applications iOS et Android`,
+    `- [Boost Projet](${siteUrl}${getLink('/fr/prestations/boost-projet', 'fr', {})}): Renfort d'équipes techniques`,
+    `- [Accompagnement CTO](${siteUrl}${getLink('/fr/prestations/accompagnement-cto', 'fr', {})}): Conseils stratégiques techniques`,
+    `- [Intelligence Artificielle](${siteUrl}${getLink('/fr/prestations/intelligence-artificielle', 'fr', {})}): Intégration IA dans vos applications`,
+    '',
+    '## Recent Blog Posts (FR)',
+    '',
+    ...recentPostsFr.map(
+      (post) =>
+        `- [${post.data.title}](${siteUrl}${getLink('/fr/blog/articles/:id', 'fr', { id: post.data._computed.slug })}): ${post.data.metaDescription ?? post.data.excerpt ?? ''}`
+    ),
+    '',
+    '## Recent Blog Posts (EN)',
+    '',
+    ...recentPostsEn.map(
+      (post) =>
+        `- [${post.data.title}](${siteUrl}${getLink('/fr/blog/articles/:id', 'en', { id: post.data._computed.slug })}): ${post.data.metaDescription ?? post.data.excerpt ?? ''}`
+    ),
+    '',
+    '## Optional',
+    '',
+    `- [Full Content](${siteUrl}/llms-full.txt): Comprehensive version with all content inlined`,
+    `- [RSS Feed (FR)](${siteUrl}${getLink('/fr/blog/rss.xml', 'fr', {})}): French blog RSS feed`,
+    `- [RSS Feed (EN)](${siteUrl}${getLink('/fr/blog/rss.xml', 'en', {})}): English blog RSS feed`,
+  ];
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/src/routes.gen.ts
+++ b/src/routes.gen.ts
@@ -15,7 +15,8 @@ const ROUTES_CONFIG = {
         }
       },
       "posts": {
-        ":id": {}
+        ":id": {},
+        ":id.md": {}
       },
       "rss.xml": {}
     },
@@ -39,7 +40,8 @@ const ROUTES_CONFIG = {
     "blog": {
       ":page": {},
       "articles": {
-        ":id": {}
+        ":id": {},
+        ":id.md": {}
       },
       "auteurs": {
         ":author": {
@@ -64,6 +66,8 @@ const ROUTES_CONFIG = {
       "ux-design": {}
     }
   },
+  "llms-full.txt": {},
+  "llms.txt": {},
   "styleguide": {}
 } as const;
 


### PR DESCRIPTION
## Summary

Implements the [llms.txt standard](https://llmstxt.org/) with `/llms.txt` (overview) and `/llms-full.txt` (comprehensive) endpoints for AI model consumption. Adds per-article markdown endpoints (`.md`) for blog posts with automatic link discovery in the SEO component.

## Changes

- `/llms.txt`: Lightweight overview with site description, navigation, services, and recent posts
- `/llms-full.txt`: Complete documentation with full descriptions, team bios, and all article content
- `/[locale]/blog/[articles|posts]/:id.md`: Individual blog post markdown endpoints
- SEO component now supports markdown link discovery
- Route mappings updated for bilingual support

## Test Plan

- [x] Visit `/llms.txt` and verify JSON structure with site overview
- [x] Visit `/llms-full.txt` and verify complete content
- [x] Visit `/fr/blog/articles/{id}.md` and `/en/blog/posts/{id}.md` to confirm markdown rendering
- [x] Check SEO meta tags include `<link rel="alternate" type="text/markdown">` on blog articles
- [x] Verify linting passes: `pnpm lint`
- [x] Build succeeds: `pnpm build`

🤖 Generated with Claude Code