### PR TITLE
Add noindex/nofollow to styleguide and exclude from sitemap

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -44,6 +44,9 @@ export default defineConfig({
         const url = new URL(page);
         const path = url.pathname;
 
+        // Exclude styleguide page
+        if (path === '/styleguide') return false;
+
         // Exclude paginated pages (e.g. /fr/blog/2, /en/blog/authors/john/3)
         const paginationPatterns = [
           /^\/(fr|en)\/blog\/\d+$/,

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -5,6 +5,7 @@ import {
   PiWarningOctagonDuotone,
 } from 'react-icons/pi';
 
+import SEO from '@/components/seo/index.astro';
 import { Button } from '@/components/ui/button';
 import {
   Callout,
@@ -16,6 +17,15 @@ import RootLayout from '@/layouts/root-layout.astro';
 ---
 
 <RootLayout>
+  <SEO
+    slot="seo"
+    title="Styleguide"
+    description="Styleguide"
+    alternates={null}
+    breadcrumb={null}
+    noindex
+    nofollow
+  />
   <div class="container mx-auto flex flex-col gap-8 p-8">
     <h1 class="font-heading text-4xl font-bold">Styleguide</h1>
 


### PR DESCRIPTION
## Summary
- Add SEO component with noindex and nofollow directives to the styleguide page to prevent search engine indexing
- Exclude /styleguide from sitemap.xml generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)