### PR TITLE
feat: add security headers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,16 @@ Schemas are defined in `src/schemas/`. Use `getCollection()` with locale filteri
 - **UI primitives**: `src/components/ui/` (Button, Dialog, Drawer, Carousel, etc.)
 - **Styling**: Tailwind CSS with `cn()` helper (clsx + tailwind-merge)
 
+### Security Headers
+
+HTTP security headers are configured in `vercel.ts`. When adding a new external service (iframe embed, external script, font CDN, image CDN, etc.), update the `Content-Security-Policy` directive to whitelist the new domain. The relevant directives are:
+
+- `frame-src`: for iframe embeds (e.g., Pipedrive, Google Maps, YouTube)
+- `script-src`: for external scripts
+- `img-src`: for external image sources
+- `font-src`: for external font CDNs
+- `connect-src`: for fetch/XHR API calls
+
 ### Key Conventions
 
 - **Filename casing**: kebab-case enforced by ESLint

--- a/vercel.ts
+++ b/vercel.ts
@@ -15,6 +15,9 @@ export const config: VercelConfig = {
     routes.header('/(.*)', [{ key: 'X-Robots-Tag', value: 'noindex' }], {
       has: [{ type: 'host', value: 'bearstudio-site-2026.vercel.app' }],
     }),
+    // Security headers applied to all routes.
+    // When adding a new external service (iframe embed, script, font CDN, etc.),
+    // update the Content-Security-Policy directives below to whitelist the new domain.
     routes.header('/(.*)', [
       {
         key: 'Content-Security-Policy',


### PR DESCRIPTION
## Summary

Add three critical HTTP security headers to Vercel configuration:
- **Content-Security-Policy**: Restricts resource loading to trusted sources, preventing XSS attacks
- **X-Content-Type-Options**: Prevents MIME-type sniffing attacks
- **X-Frame-Options**: Prevents clickjacking by blocking frame embedding

## Details

The CSP policy allows embedded iframes for Pipedrive contact forms, Google Maps, and YouTube while restricting all other external resources. All fonts are self-hosted via Fontsource packages, eliminating external font CDN dependencies. Scripts and styles use `unsafe-inline` only where necessary for Astro island hydration and Tailwind CSS.

## Security Impact

These headers significantly improve the site's security posture by:
- Blocking unauthorized script injection
- Preventing content-type exploits
- Protecting against clickjacking attacks
- Establishing a defense-in-depth security model

🤖 Generated with [Claude Code](https://claude.com/claude-code)