### PR TITLE
Update README with project-specific content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,56 @@
-# Astro Starter Kit: Blog
+# BearStudio Website
 
-```sh
-pnpm create astro@latest -- --template blog
+The multilingual (French/English) website for [BearStudio](https://bearstudio.fr), built with [Astro](https://astro.build) and React.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) >= 20
+- [pnpm](https://pnpm.io/)
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm dev
 ```
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+The dev server starts at `http://localhost:4321`.
 
-Features:
+## Commands
 
-- ✅ Minimal styling (make it your own!)
-- ✅ 100/100 Lighthouse performance
-- ✅ SEO-friendly with canonical URLs and OpenGraph data
-- ✅ Sitemap support
-- ✅ RSS Feed support
-- ✅ Markdown & MDX support
+| Command         | Description                              |
+| :-------------- | :--------------------------------------- |
+| `pnpm dev`      | Start dev server at `localhost:4321`     |
+| `pnpm build`    | Build production site to `./dist/`       |
+| `pnpm preview`  | Preview production build locally         |
+| `pnpm lint`     | Run all linters (astro check, eslint, tsc) |
+| `pnpm pretty`   | Format code with Prettier                |
 
-## 🚀 Project Structure
+## Project Structure
 
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-├── public/
-├── src/
-│   ├── components/
-│   ├── content/
-│   ├── layouts/
-│   └── pages/
-├── astro.config.mjs
-├── README.md
-├── package.json
-└── tsconfig.json
+```
+src/
+├── components/     # Astro & React components
+│   └── ui/         # Reusable UI primitives (Button, Dialog, Carousel, etc.)
+├── content/        # Content collections (Markdown/MDX)
+│   ├── posts/      # Blog articles
+│   ├── people/     # Team members
+│   ├── conferences/# Speaking events
+│   ├── polaroids/  # Homepage images
+│   └── skills/     # Technology tags
+├── i18n/           # Translations (fr/ and en/)
+├── layouts/        # Page layouts (RootLayout → MainLayout → Page)
+├── lib/            # Shared utilities
+├── pages/
+│   ├── fr/         # French pages (default locale)
+│   └── en/         # English pages
+└── schemas/        # Content collection schemas
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Tech Stack
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-The `src/content/` directory contains "collections" of related Markdown and MDX documents. Use `getCollection()` to retrieve posts from `src/content/blog/`, and type-check your frontmatter using an optional schema. See [Astro's Content Collections docs](https://docs.astro.build/en/guides/content-collections/) to learn more.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                | Action                                           |
-| :--------------------- | :----------------------------------------------- |
-| `pnpm install`         | Installs dependencies                            |
-| `pnpm dev`             | Starts local dev server at `localhost:4321`      |
-| `pnpm build`           | Build your production site to `./dist/`          |
-| `pnpm preview`         | Preview your build locally, before deploying     |
-| `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `pnpm astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
-
-## Credit
-
-This theme is based off of the lovely [Bear Blog](https://github.com/HermanMartinus/bearblog/).
+- **[Astro](https://astro.build)** - Static site generation
+- **[React](https://react.dev)** - Interactive islands
+- **[Tailwind CSS](https://tailwindcss.com)** - Styling
+- **[MDX](https://mdxjs.com)** - Blog content
+- **[Radix UI](https://www.radix-ui.com)** - Accessible UI primitives


### PR DESCRIPTION
## Summary
Replace the default Astro starter kit README with documentation tailored for BearStudio's multilingual website. The new README includes prerequisites, getting started instructions, an accurate project structure overview, and the tech stack.

## What's Changed
- Updated title and description to reflect the BearStudio project
- Added prerequisites section (Node.js >= 20, pnpm)
- Added Getting Started section for quick onboarding
- Updated commands table to match actual package.json scripts
- Replaced generic project structure with BearStudio-specific layout (content collections, i18n, layouts, etc.)
- Added Tech Stack section highlighting key technologies

🤖 Generated with Claude Code