### PR TITLE
Remove Content-Security-Policy header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,16 +51,6 @@ Schemas are defined in `src/schemas/`. Use `getCollection()` with locale filteri
 - **UI primitives**: `src/components/ui/` (Button, Dialog, Drawer, Carousel, etc.)
 - **Styling**: Tailwind CSS with `cn()` helper (clsx + tailwind-merge)
 
-### Security Headers
-
-HTTP security headers are configured in `vercel.ts`. When adding a new external service (iframe embed, external script, font CDN, image CDN, etc.), update the `Content-Security-Policy` directive to whitelist the new domain. The relevant directives are:
-
-- `frame-src`: for iframe embeds (e.g., Pipedrive, Google Maps, YouTube)
-- `script-src`: for external scripts
-- `img-src`: for external image sources
-- `font-src`: for external font CDNs
-- `connect-src`: for fetch/XHR API calls
-
 ### Key Conventions
 
 - **Filename casing**: kebab-case enforced by ESLint

--- a/vercel.ts
+++ b/vercel.ts
@@ -15,25 +15,7 @@ export const config: VercelConfig = {
     routes.header('/(.*)', [{ key: 'X-Robots-Tag', value: 'noindex' }], {
       has: [{ type: 'host', value: 'bearstudio-site-2026.vercel.app' }],
     }),
-    // Security headers applied to all routes.
-    // When adding a new external service (iframe embed, script, font CDN, etc.),
-    // update the Content-Security-Policy directives below to whitelist the new domain.
     routes.header('/(.*)', [
-      {
-        key: 'Content-Security-Policy',
-        value: [
-          "default-src 'self'",
-          "script-src 'self' 'unsafe-inline'",
-          "style-src 'self' 'unsafe-inline'",
-          "img-src 'self' data: https://pbs.twimg.com",
-          "font-src 'self' data:",
-          'frame-src https://webforms.pipedrive.com https://www.google.com https://www.youtube-nocookie.com',
-          "connect-src 'self'",
-          "base-uri 'self'",
-          "form-action 'self'",
-          "frame-ancestors 'none'",
-        ].join('; '),
-      },
       {
         key: 'X-Content-Type-Options',
         value: 'nosniff',
@@ -44,8 +26,6 @@ export const config: VercelConfig = {
       },
       {
         key: 'Referrer-Policy',
-        // We don't have anything sensitive in the URL for our site, so we just
-        // keep referrer data off HTTP connections.
         value: 'strict-origin-when-cross-origin',
       },
     ]),


### PR DESCRIPTION
## Summary
- Remove the `Content-Security-Policy` header from `vercel.ts` — it was unnecessarily restrictive for a static site where we control all content
- Keep other security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`)
- Remove related CSP documentation from `CLAUDE.md`

## Test plan
- [ ] Verify the site loads correctly on Vercel preview without CSP errors
- [ ] Confirm external embeds (Pipedrive, YouTube, Google Maps) work without needing CSP whitelisting

🤖 Generated with [Claude Code](https://claude.com/claude-code)