### PR TITLE
feat: add Vercel Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fontsource-variable/inter": "5.2.8",
     "@fontsource-variable/roboto-slab": "5.2.8",
     "@tailwindcss/vite": "4.1.18",
+    "@vercel/analytics": "2.0.1",
     "@vercel/config": "0.0.28",
     "astro": "6.0.1",
     "astro-robots-txt": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
+      '@vercel/analytics':
+        specifier: 2.0.1
+        version: 2.0.1(react@19.2.4)
       '@vercel/config':
         specifier: 0.0.28
         version: 0.0.28
@@ -2003,6 +2006,35 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/config@0.0.28':
     resolution: {integrity: sha512-lGnGmac05Rt+dYNwn6Rfub5GCnhSS33f3oQ3+1SSWw7zaI1gCaBDVetGtAIM5cMGG6UkGcRRSp1sw0dibS5wUQ==}
@@ -6814,6 +6846,10 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vercel/analytics@2.0.1(react@19.2.4)':
+    optionalDependencies:
+      react: 19.2.4
 
   '@vercel/config@0.0.28':
     dependencies:

--- a/src/layouts/root-layout.astro
+++ b/src/layouts/root-layout.astro
@@ -11,6 +11,8 @@ import '@/styles/global.css';
 
 import { Schema } from 'astro-seo-schema';
 
+import Analytics from '@vercel/analytics/astro';
+
 import { getLink } from '@/lib/link';
 import { getSiteUrl } from '@/lib/site/get-site-url';
 import { getTranslationUtilities } from '@/lib/site/get-translation-utilities';
@@ -54,6 +56,8 @@ dayjs.locale(Astro.currentLocale);
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-title" content="BearStudio" />
     <link rel="manifest" href="/site.webmanifest" />
+
+    <Analytics />
 
     <slot name="seo" />
     <slot name="ld+json" />


### PR DESCRIPTION
## Summary
- Install `@vercel/analytics` and add `<Analytics />` component to the `<head>` in the root layout

## Test plan
- [ ] Verify the site builds successfully
- [ ] Check that the Vercel Analytics script loads on pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)