### PR TITLE
feat: declare AI content usage via Content Signals in robots.txt

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -66,6 +66,12 @@ export default defineConfig({
           disallow: ['/styleguide'],
         },
       ],
+      transform(content) {
+        return content.replace(
+          /^User-agent: \*$/m,
+          'User-agent: *\nContent-Signal: ai-train=no, search=yes, ai-input=no'
+        );
+      },
     }),
     bearstudioTypedRoutes(),
   ],


### PR DESCRIPTION
## Summary
- Add a `transform` step to the `astro-robots-txt` integration that injects a `Content-Signal: ai-train=no, search=yes, ai-input=no` directive under the `User-agent: *` group, declaring AI content usage preferences per the [Content Signals](https://contentsignals.org/) spec.

## Test plan
- [x] `pnpm build` succeeds and `dist/robots.txt` contains the `Content-Signal` line directly under `User-agent: *`
- [ ] Verify deployed `https://www.bearstudio.fr/robots.txt` exposes the directive after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)