### PR TITLE
feat: add Link response headers for agent discovery

### DIFF
--- a/vercel.ts
+++ b/vercel.ts
@@ -28,6 +28,11 @@ export const config: VercelConfig = {
         key: 'Referrer-Policy',
         value: 'strict-origin-when-cross-origin',
       },
+      {
+        key: 'Link',
+        value:
+          '</llms.txt>; rel="service-doc"; type="text/plain", </llms.txt>; rel="describedby"; type="text/plain", </sitemap-index.xml>; rel="sitemap"; type="application/xml"',
+      },
     ]),
   ],
 };


### PR DESCRIPTION
## Summary
- Add a site-wide `Link` HTTP response header in `vercel.ts` so agents can discover useful resources per RFC 8288.
- Advertises `/llms.txt` (`rel="service-doc"` and `rel="describedby"`) and `/sitemap-index.xml` (`rel="sitemap"`).

## Test plan
- [ ] After Vercel preview deploy, run `curl -I https://<preview-url>/` and confirm a `Link:` header is present with the three rels.
- [ ] Validate via `https://isitagentready.com/api/scan` — `checks.discoverability.linkHeaders.status` should be `pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)