### PR TITLE
feat: declare AI content usage preferences via Content Signals

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -66,6 +66,9 @@ export default defineConfig({
           disallow: ['/styleguide'],
         },
       ],
+      // Declare AI content usage preferences — https://contentsignals.org/
+      transform: (content) =>
+        `${content}\nContent-Signal: ai-train=no, search=yes, ai-input=no\n`,
     }),
     bearstudioTypedRoutes(),
   ],


### PR DESCRIPTION
## Pourquoi

Les crawlers et modèles d'IA n'ont actuellement aucune indication sur nos préférences d'utilisation du contenu. La spécification [Content Signals](https://contentsignals.org/) (draft IETF) permet de déclarer ces préférences directement dans le `robots.txt`.

## Ce qui change

Ajout d'une directive `Content-Signal` dans le `robots.txt` généré, via l'option `transform` du plugin `astro-robots-txt` déjà en place :

```
Content-Signal: ai-train=no, search=yes, ai-input=no
```

- `ai-train=no` — interdit l'utilisation du contenu pour entraîner des modèles d'IA
- `search=yes` — autorise l'indexation par les moteurs de recherche
- `ai-input=no` — interdit l'utilisation du contenu comme input dans des systèmes d'IA (RAG, etc.)

## Refs

- https://contentsignals.org/
- https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/

🤖 Generated with [Claude Code](https://claude.com/claude-code)