### PR TITLE
feat: blog-post components

### DIFF
--- a/src/components/blog-post/feature-card-grid.astro
+++ b/src/components/blog-post/feature-card-grid.astro
@@ -4,7 +4,7 @@ import { LuCalendar, LuImage, LuType } from 'react-icons/lu';
 import FeatureCard from './feature-card.astro';
 ---
 
-<div class="grid max-w-xl grid-cols-2 gap-4">
+<div class="grid max-w-xl grid-cols-1 gap-4 sm:grid-cols-2">
   <FeatureCard
     icon={LuCalendar}
     title="Âge présent mais secondaire"

--- a/src/components/blog-post/feature-card-grid.astro
+++ b/src/components/blog-post/feature-card-grid.astro
@@ -1,0 +1,23 @@
+---
+import { LuCalendar, LuImage, LuType } from 'react-icons/lu';
+
+import FeatureCard from './feature-card.astro';
+---
+
+<div class="grid max-w-xl grid-cols-2 gap-4">
+  <FeatureCard
+    icon={LuCalendar}
+    title="Âge présent mais secondaire"
+    content="Visible, sans voler l'attention"
+  />
+  <FeatureCard
+    icon={LuType}
+    title="Titre optimisé"
+    content="Typographie, espace, nombre de lignes soigneusement pensés"
+  />
+  <FeatureCard
+    icon={LuImage}
+    title="Image dominante"
+    content="L'œil décide d'abord par le visuel, et le cerveau suit."
+  />
+</div>

--- a/src/components/blog-post/feature-card.astro
+++ b/src/components/blog-post/feature-card.astro
@@ -1,0 +1,43 @@
+---
+import type { IconType } from 'react-icons/lib';
+
+import { cn } from '@/lib/tailwind/utils';
+
+interface Props {
+  icon: IconType;
+  title: string;
+  content: string;
+  class?: string;
+}
+
+const { icon: Icon, title, content, class: className } = Astro.props;
+---
+
+<div
+  data-slot="feature-card"
+  class={cn(
+    'not-prose inline-flex flex-col items-start gap-4 self-stretch rounded-md bg-brand-700 p-4',
+    className
+  )}
+>
+  <div class="flex items-center gap-3">
+    <div
+      data-slot="feature-card-icon"
+      class="bg-brand-600 text-brand-200 flex size-8 shrink-0 items-center justify-center rounded-sm pb-0.5 [&>svg]:size-3.25"
+    >
+      <Icon />
+    </div>
+    <p
+      data-slot="feature-card-title"
+      class="font-heading text-brand-100 text-md font-normal"
+    >
+      {title}
+    </p>
+  </div>
+  <div
+    data-slot="feature-card-content"
+    class="text-brand-200 text-xs leading-relaxed font-light"
+  >
+    {content}
+  </div>
+</div>

--- a/src/components/blog-post/feature-card.astro
+++ b/src/components/blog-post/feature-card.astro
@@ -16,7 +16,7 @@ const { icon: Icon, title, content, class: className } = Astro.props;
 <div
   data-slot="feature-card"
   class={cn(
-    'not-prose inline-flex flex-col items-start gap-4 self-stretch rounded-md bg-brand-700 p-4',
+    'not-prose inline-flex flex-col items-start gap-4 self-stretch rounded-md bg-brand-700 p-4 border border-brand-600',
     className
   )}
 >

--- a/src/components/blog-post/feature-card.astro
+++ b/src/components/blog-post/feature-card.astro
@@ -23,7 +23,7 @@ const { icon: Icon, title, content, class: className } = Astro.props;
   <div class="flex items-center gap-3">
     <div
       data-slot="feature-card-icon"
-      class="bg-brand-600 text-brand-200 flex size-8 shrink-0 items-center justify-center rounded-sm pb-0.5 [&>svg]:size-3.25"
+      class="bg-brand-600 text-brand-200 flex size-8 shrink-0 items-center justify-center self-start rounded-sm pb-0.5 [&>svg]:size-3.25"
     >
       <Icon />
     </div>

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -79,7 +79,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
               aria-label={`Aller au slide ${i + 1}`}
               className={cn(
                 'h-1.5 rounded-full transition-all',
-                i === current ? 'w-4 bg-accent' : 'w-1.5 bg-brand-600'
+                i === current ? 'w-4 bg-brand-100' : 'w-1.5 bg-brand-700'
               )}
             />
           ))}

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { PiArrowLeft, PiArrowRight } from 'react-icons/pi';
+import { PiCaretLeft, PiCaretRight } from 'react-icons/pi';
 
 import { cn } from '@/lib/tailwind/utils';
 import { Button } from '@/components/ui/button';
@@ -67,7 +67,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
           aria-label="Slide précédent"
           className="rounded-full"
         >
-          <PiArrowLeft className="size-4" />
+          <PiCaretLeft className="size-4" />
         </Button>
 
         {/* Dots */}
@@ -80,7 +80,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
               aria-label={`Aller au slide ${i + 1}`}
               className={cn(
                 'h-1.5 rounded-full transition-all',
-                i === current ? 'w-4 bg-brand-500' : 'w-1.5 bg-muted'
+                i === current ? 'w-4 bg-foreground' : 'w-1.5 bg-muted'
               )}
             />
           ))}
@@ -94,7 +94,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
           aria-label="Slide suivant"
           className="rounded-full"
         >
-          <PiArrowRight className="size-4" />
+          <PiCaretRight className="size-4" />
         </Button>
       </div>
     </div>

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+
+import { PiArrowLeft, PiArrowRight } from 'react-icons/pi';
+
+import { cn } from '@/lib/tailwind/utils';
+
+type Slide = {
+  src: string;
+  alt?: string;
+};
+
+type PhoneCarouselProps = {
+  slides: Slide[];
+  className?: string;
+};
+
+export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
+  const [current, setCurrent] = React.useState(0);
+  const count = slides.length;
+
+  const prev = () => setCurrent((c) => Math.max(0, c - 1));
+  const next = () => setCurrent((c) => Math.min(count - 1, c + 1));
+
+  return (
+    <div
+      data-slot="phone-carousel"
+      className={cn('not-prose flex flex-col items-center gap-4', className)}
+    >
+      {/* Phone frame — fixed size, images scroll inside */}
+      <div className="relative w-[220px] shrink-0">
+        {/* Outer shell */}
+        <div className="relative rounded-[2.8rem] border-[8px] border-brand-50 bg-brand-50 shadow-xl ring-1 ring-brand-200/40">
+          {/* Notch */}
+          <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-brand-50" />
+          {/* Screen — overflow hidden, images slide inside */}
+          <div className="overflow-hidden rounded-[2.2rem] bg-white">
+            <div
+              className="flex transition-transform duration-300 ease-in-out"
+              style={{ transform: `translateX(-${current * 100}%)` }}
+            >
+              {slides.map((slide, i) => (
+                <img
+                  key={i}
+                  src={slide.src}
+                  alt={slide.alt ?? `Écran ${i + 1}`}
+                  className="w-full shrink-0 object-cover"
+                  draggable={false}
+                />
+              ))}
+            </div>
+          </div>
+          {/* Home bar */}
+          <div className="flex justify-center pb-2 pt-1">
+            <div className="h-1 w-16 rounded-full bg-brand-300/60" />
+          </div>
+        </div>
+      </div>
+
+      {/* Controls below the phone */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={prev}
+          disabled={current === 0}
+          className="flex size-9 shrink-0 items-center justify-center rounded-full border border-brand-600 bg-brand-700 text-brand-200 transition-opacity disabled:opacity-30 hover:bg-brand-600"
+          aria-label="Slide précédent"
+        >
+          <PiArrowLeft className="size-4" />
+        </button>
+
+        {/* Dots */}
+        <div className="flex gap-1.5">
+          {slides.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => setCurrent(i)}
+              aria-label={`Aller au slide ${i + 1}`}
+              className={cn(
+                'h-1.5 rounded-full transition-all',
+                i === current ? 'w-4 bg-accent' : 'w-1.5 bg-brand-600'
+              )}
+            />
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={next}
+          disabled={current === count - 1}
+          className="flex size-9 shrink-0 items-center justify-center rounded-full border border-brand-600 bg-brand-700 text-brand-200 transition-opacity disabled:opacity-30 hover:bg-brand-600"
+          aria-label="Slide suivant"
+        >
+          <PiArrowRight className="size-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -51,7 +51,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
             </div>
           </div>
           {/* Home bar */}
-          <div className="flex justify-center pb-2 pt-1">
+          <div className="flex justify-center py-1">
             <div className="h-1 w-16 rounded-full bg-neutral-700" />
           </div>
         </div>

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -4,6 +4,12 @@ import { PiCaretLeft, PiCaretRight } from 'react-icons/pi';
 
 import { cn } from '@/lib/tailwind/utils';
 import { Button } from '@/components/ui/button';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  type CarouselApi,
+} from '@/components/ui/carousel';
 
 type Slide = {
   src: string;
@@ -16,53 +22,44 @@ type PhoneCarouselProps = {
 };
 
 export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
+  const [api, setApi] = React.useState<CarouselApi>();
   const [current, setCurrent] = React.useState(0);
   const count = slides.length;
 
-  const prev = () => setCurrent((c) => Math.max(0, c - 1));
-  const next = () => setCurrent((c) => Math.min(count - 1, c + 1));
+  React.useEffect(() => {
+    if (!api) return;
+    setCurrent(api.selectedScrollSnap());
+    api.on('select', () => setCurrent(api.selectedScrollSnap()));
+  }, [api]);
 
   return (
     <div
       data-slot="phone-carousel"
       className={cn('not-prose flex flex-col items-center gap-4', className)}
     >
-      {/* Phone frame — fixed size, images scroll inside */}
-      <div className="relative w-[220px] shrink-0">
-        {/* Outer shell */}
-        <div className="relative rounded-[2.8rem] border-[8px] border-neutral-900 bg-neutral-900 shadow-xl ring-1 ring-neutral-700/60">
-          {/* Notch */}
-          <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-neutral-900" />
-          {/* Screen — overflow hidden, images slide inside */}
-          <div className="overflow-hidden rounded-[2.2rem] bg-white">
-            <div
-              className="flex transition-transform duration-300 ease-in-out"
-              style={{ transform: `translateX(-${current * 100}%)` }}
-            >
-              {slides.map((slide, i) => (
+      <PhoneFrame>
+        <Carousel setApi={setApi} className="w-full">
+          <CarouselContent>
+            {slides.map((slide, i) => (
+              <CarouselItem key={slide.src}>
                 <img
-                  key={i}
                   src={slide.src}
                   alt={slide.alt ?? `Écran ${i + 1}`}
-                  className="w-full shrink-0 object-cover"
+                  className="block w-full object-cover"
                   draggable={false}
                 />
-              ))}
-            </div>
-          </div>
-          {/* Home bar */}
-          <div className="flex justify-center py-1">
-            <div className="h-1 w-16 rounded-full bg-neutral-700" />
-          </div>
-        </div>
-      </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
+      </PhoneFrame>
 
       {/* Controls below the phone */}
       <div className="flex items-center gap-3">
         <Button
           variant="secondary"
           size="icon"
-          onClick={prev}
+          onClick={() => api?.scrollPrev()}
           disabled={current === 0}
           aria-label="Slide précédent"
           className="rounded-full"
@@ -76,11 +73,11 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
             <button
               key={i}
               type="button"
-              onClick={() => setCurrent(i)}
+              onClick={() => api?.scrollTo(i)}
               aria-label={`Aller au slide ${i + 1}`}
               className={cn(
                 'h-1.5 rounded-full transition-all',
-                i === current ? 'w-4 bg-foreground' : 'w-1.5 bg-muted'
+                i === current ? 'w-4 bg-brand-500' : 'w-1.5 bg-muted'
               )}
             />
           ))}
@@ -89,13 +86,32 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
         <Button
           variant="secondary"
           size="icon"
-          onClick={next}
+          onClick={() => api?.scrollNext()}
           disabled={current === count - 1}
           aria-label="Slide suivant"
           className="rounded-full"
         >
           <PiCaretRight className="size-4" />
         </Button>
+      </div>
+    </div>
+  );
+}
+
+function PhoneFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative w-[220px] shrink-0">
+      <div className="relative rounded-[2.8rem] border-[8px] border-neutral-900 bg-neutral-900 shadow-xl ring-1 ring-neutral-700/60">
+        {/* Notch */}
+        <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-neutral-900" />
+        {/* Screen */}
+        <div className="overflow-hidden rounded-[2.2rem] bg-white">
+          {children}
+        </div>
+        {/* Home bar */}
+        <div className="flex justify-center py-1">
+          <div className="h-1 w-16 rounded-full bg-neutral-700" />
+        </div>
       </div>
     </div>
   );

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { PiArrowLeft, PiArrowRight } from 'react-icons/pi';
 
 import { cn } from '@/lib/tailwind/utils';
+import { Button } from '@/components/ui/button';
 
 type Slide = {
   src: string;
@@ -29,9 +30,9 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
       {/* Phone frame — fixed size, images scroll inside */}
       <div className="relative w-[220px] shrink-0">
         {/* Outer shell */}
-        <div className="relative rounded-[2.8rem] border-[8px] border-brand-50 bg-brand-50 shadow-xl ring-1 ring-brand-200/40">
+        <div className="relative rounded-[2.8rem] border-[8px] border-neutral-900 bg-neutral-900 shadow-xl ring-1 ring-neutral-700/60">
           {/* Notch */}
-          <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-brand-50" />
+          <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-neutral-900" />
           {/* Screen — overflow hidden, images slide inside */}
           <div className="overflow-hidden rounded-[2.2rem] bg-white">
             <div
@@ -51,22 +52,22 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
           </div>
           {/* Home bar */}
           <div className="flex justify-center pb-2 pt-1">
-            <div className="h-1 w-16 rounded-full bg-brand-300/60" />
+            <div className="h-1 w-16 rounded-full bg-neutral-700" />
           </div>
         </div>
       </div>
 
       {/* Controls below the phone */}
       <div className="flex items-center gap-3">
-        <button
-          type="button"
+        <Button
+          variant="secondary"
+          size="icon"
           onClick={prev}
           disabled={current === 0}
-          className="flex size-9 shrink-0 items-center justify-center rounded-full border border-brand-600 bg-brand-700 text-brand-200 transition-opacity disabled:opacity-30 hover:bg-brand-600"
           aria-label="Slide précédent"
         >
           <PiArrowLeft className="size-4" />
-        </button>
+        </Button>
 
         {/* Dots */}
         <div className="flex gap-1.5">
@@ -84,15 +85,15 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
           ))}
         </div>
 
-        <button
-          type="button"
+        <Button
+          variant="secondary"
+          size="icon"
           onClick={next}
           disabled={current === count - 1}
-          className="flex size-9 shrink-0 items-center justify-center rounded-full border border-brand-600 bg-brand-700 text-brand-200 transition-opacity disabled:opacity-30 hover:bg-brand-600"
           aria-label="Slide suivant"
         >
           <PiArrowRight className="size-4" />
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -80,7 +80,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
               aria-label={`Aller au slide ${i + 1}`}
               className={cn(
                 'h-1.5 rounded-full transition-all',
-                i === current ? 'w-4 bg-brand-100' : 'w-1.5 bg-brand-700'
+                i === current ? 'w-4 bg-brand-500' : 'w-1.5 bg-muted'
               )}
             />
           ))}

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -10,17 +10,19 @@ import {
   type CarouselApi,
 } from '@/components/ui/carousel';
 
-type Slide = {
-  src: string;
-  alt?: string;
-};
-
 type PhoneCarouselProps = {
-  slides: Slide[];
+  slides: { src: string; alt?: string }[];
+  width?: number;
+  dark?: boolean;
   className?: string;
 };
 
-export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
+export function PhoneCarousel({
+  slides,
+  width = 220,
+  dark = false,
+  className,
+}: PhoneCarouselProps) {
   const [api, setApi] = React.useState<CarouselApi>();
   const [current, setCurrent] = React.useState(0);
 
@@ -38,62 +40,52 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
       data-slot="phone-carousel"
       className={cn('not-prose flex flex-col items-center gap-4', className)}
     >
-      <PhoneFrame>
-        <Carousel setApi={setApi} className="w-full">
-          <CarouselContent>
+      <Carousel setApi={setApi} style={{ width }} className="shrink-0">
+        <div className="relative rounded-[2.8rem] border-8 border-neutral-900 bg-neutral-900 shadow-xl ring-1 ring-neutral-700/60">
+          <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-neutral-900" />
+          <div className="overflow-hidden rounded-[2.2rem]">
+            <CarouselContent className="ml-0">
+              {slides.map((slide, i) => (
+                <CarouselItem key={slide.src} className="pl-0">
+                  <img
+                    src={slide.src}
+                    alt={slide.alt ?? `Écran ${i + 1}`}
+                    className="block w-full object-cover"
+                    draggable={false}
+                  />
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+          </div>
+        </div>
+
+        <div className="mt-4 flex items-center justify-center gap-3">
+          <CarouselPrevious
+            variant={dark ? 'secondaryOnDark' : 'secondary'}
+            className="static translate-y-0"
+          />
+          <div className="flex gap-1.5">
             {slides.map((slide, i) => (
-              <CarouselItem key={slide.src}>
-                <img
-                  src={slide.src}
-                  alt={slide.alt ?? `Écran ${i + 1}`}
-                  className="block w-full object-cover"
-                  draggable={false}
-                />
-              </CarouselItem>
+              <button
+                key={slide.src}
+                type="button"
+                onClick={() => api?.scrollTo(i)}
+                aria-label={`Aller au slide ${i + 1}`}
+                className={cn(
+                  'h-1.5 rounded-full transition-all',
+                  i === current
+                    ? cn('w-4', dark ? 'bg-background' : 'bg-brand-500')
+                    : cn('w-1.5', dark ? 'bg-white/30' : 'bg-muted')
+                )}
+              />
             ))}
-          </CarouselContent>
-        </Carousel>
-      </PhoneFrame>
-
-      <div className="flex items-center gap-3">
-        <CarouselPrevious
-          variant="secondary"
-          className="static translate-y-0"
-        />
-
-        <div className="flex gap-1.5">
-          {slides.map((slide, i) => (
-            <button
-              key={slide.src}
-              type="button"
-              onClick={() => api?.scrollTo(i)}
-              aria-label={`Aller au slide ${i + 1}`}
-              className={cn(
-                'h-1.5 rounded-full transition-all',
-                i === current ? 'w-4 bg-brand-500' : 'w-1.5 bg-muted'
-              )}
-            />
-          ))}
+          </div>
+          <CarouselNext
+            variant={dark ? 'secondaryOnDark' : 'secondary'}
+            className="static translate-y-0"
+          />
         </div>
-
-        <CarouselNext variant="secondary" className="static translate-y-0" />
-      </div>
-    </div>
-  );
-}
-
-function PhoneFrame({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="relative w-[220px] shrink-0">
-      <div className="relative rounded-[2.8rem] border-[8px] border-neutral-900 bg-neutral-900 shadow-xl ring-1 ring-neutral-700/60">
-        <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-neutral-900" />
-        <div className="overflow-hidden rounded-[2.2rem] bg-white">
-          {children}
-        </div>
-        <div className="flex justify-center py-1">
-          <div className="h-1 w-16 rounded-full bg-neutral-700" />
-        </div>
-      </div>
+      </Carousel>
     </div>
   );
 }

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -65,6 +65,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
           onClick={prev}
           disabled={current === 0}
           aria-label="Slide précédent"
+          className="rounded-full"
         >
           <PiArrowLeft className="size-4" />
         </Button>
@@ -91,6 +92,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
           onClick={next}
           disabled={current === count - 1}
           aria-label="Slide suivant"
+          className="rounded-full"
         >
           <PiArrowRight className="size-4" />
         </Button>

--- a/src/components/blog-post/phone-carousel.tsx
+++ b/src/components/blog-post/phone-carousel.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 
-import { PiCaretLeft, PiCaretRight } from 'react-icons/pi';
-
 import { cn } from '@/lib/tailwind/utils';
-import { Button } from '@/components/ui/button';
 import {
   Carousel,
   CarouselContent,
   CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
   type CarouselApi,
 } from '@/components/ui/carousel';
 
@@ -24,12 +23,14 @@ type PhoneCarouselProps = {
 export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
   const [api, setApi] = React.useState<CarouselApi>();
   const [current, setCurrent] = React.useState(0);
-  const count = slides.length;
 
   React.useEffect(() => {
     if (!api) return;
-    setCurrent(api.selectedScrollSnap());
-    api.on('select', () => setCurrent(api.selectedScrollSnap()));
+    const onSelect = () => setCurrent(api.selectedScrollSnap());
+    api.on('select', onSelect);
+    return () => {
+      api.off('select', onSelect);
+    };
   }, [api]);
 
   return (
@@ -54,24 +55,16 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
         </Carousel>
       </PhoneFrame>
 
-      {/* Controls below the phone */}
       <div className="flex items-center gap-3">
-        <Button
+        <CarouselPrevious
           variant="secondary"
-          size="icon"
-          onClick={() => api?.scrollPrev()}
-          disabled={current === 0}
-          aria-label="Slide précédent"
-          className="rounded-full"
-        >
-          <PiCaretLeft className="size-4" />
-        </Button>
+          className="static translate-y-0"
+        />
 
-        {/* Dots */}
         <div className="flex gap-1.5">
-          {slides.map((_, i) => (
+          {slides.map((slide, i) => (
             <button
-              key={i}
+              key={slide.src}
               type="button"
               onClick={() => api?.scrollTo(i)}
               aria-label={`Aller au slide ${i + 1}`}
@@ -83,16 +76,7 @@ export function PhoneCarousel({ slides, className }: PhoneCarouselProps) {
           ))}
         </div>
 
-        <Button
-          variant="secondary"
-          size="icon"
-          onClick={() => api?.scrollNext()}
-          disabled={current === count - 1}
-          aria-label="Slide suivant"
-          className="rounded-full"
-        >
-          <PiCaretRight className="size-4" />
-        </Button>
+        <CarouselNext variant="secondary" className="static translate-y-0" />
       </div>
     </div>
   );
@@ -102,13 +86,10 @@ function PhoneFrame({ children }: { children: React.ReactNode }) {
   return (
     <div className="relative w-[220px] shrink-0">
       <div className="relative rounded-[2.8rem] border-[8px] border-neutral-900 bg-neutral-900 shadow-xl ring-1 ring-neutral-700/60">
-        {/* Notch */}
         <div className="absolute top-0 left-1/2 z-10 h-5 w-24 -translate-x-1/2 rounded-b-xl bg-neutral-900" />
-        {/* Screen */}
         <div className="overflow-hidden rounded-[2.2rem] bg-white">
           {children}
         </div>
-        {/* Home bar */}
         <div className="flex justify-center py-1">
           <div className="h-1 w-16 rounded-full bg-neutral-700" />
         </div>

--- a/src/components/blog-post/role-card.astro
+++ b/src/components/blog-post/role-card.astro
@@ -90,7 +90,7 @@ const {
                       rel="noopener noreferrer"
                       class="text-brand-200 hover:text-brand-100 transition-colors"
                     >
-                      <PiArrowSquareOut class="size-[10px]" />
+                      <PiArrowSquareOut className="size-[10px]" />
                     </a>
                   )}
                 </div>

--- a/src/components/blog-post/role-card.astro
+++ b/src/components/blog-post/role-card.astro
@@ -32,12 +32,12 @@ const {
 <div
   data-slot="role-card"
   class={cn(
-    'not-prose flex gap-10 rounded-md border border-brand-600 bg-foreground p-8',
+    'not-prose flex flex-col gap-6 rounded-md border border-brand-600 bg-foreground p-8 lg:flex-row lg:gap-10',
     className
   )}
 >
   <!-- Left -->
-  <div class="flex w-2/5 shrink-0 flex-col gap-4">
+  <div class="flex w-full shrink-0 flex-col gap-4 lg:w-2/5">
     <!-- Header -->
     <div class="flex items-center gap-4">
       <div

--- a/src/components/blog-post/role-card.astro
+++ b/src/components/blog-post/role-card.astro
@@ -1,0 +1,116 @@
+---
+import type { IconType } from 'react-icons/lib';
+import { PiArrowSquareOut } from 'react-icons/pi';
+
+import { cn } from '@/lib/tailwind/utils';
+
+interface TeamMember {
+  name: string;
+  title: string;
+  url?: string;
+}
+
+interface Props {
+  icon: IconType;
+  role: string;
+  description: string;
+  tags?: string[];
+  team?: TeamMember[];
+  class?: string;
+}
+
+const {
+  icon: Icon,
+  role,
+  description,
+  tags = [],
+  team = [],
+  class: className,
+} = Astro.props;
+---
+
+<div
+  data-slot="role-card"
+  class={cn(
+    'not-prose flex gap-10 rounded-md border border-brand-600 bg-foreground p-8',
+    className
+  )}
+>
+  <!-- Left -->
+  <div class="flex w-2/5 shrink-0 flex-col gap-4">
+    <!-- Header -->
+    <div class="flex items-center gap-4">
+      <div
+        class="bg-brand-700 text-brand-200 border-brand-600 flex size-12 shrink-0 items-center justify-center gap-1 rounded-[6px] border pb-0.5 [&>svg]:size-5"
+      >
+        <Icon />
+      </div>
+      <div>
+        <p class="text-brand-200 text-sm leading-[21px] font-normal">Rôle</p>
+        <p class="font-heading text-brand-50 text-2xl leading-8 font-medium">
+          {role}
+        </p>
+      </div>
+    </div>
+
+    <!-- Description -->
+    <p class="text-brand-200 text-sm leading-relaxed font-light">
+      {description}
+    </p>
+
+    <!-- Tags -->
+    {
+      tags.length > 0 && (
+        <div class="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <span class="border-brand-600 inline-flex h-5 items-center justify-center gap-2 rounded-full border px-2 text-center text-xs leading-[18px] font-medium text-white">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )
+    }
+
+    <!-- Team -->
+    {
+      team.length > 0 && (
+        <div class="flex flex-col gap-3">
+          <p class="text-brand-200 text-sm leading-[21px] font-normal">
+            Équipe sur ce rôle
+          </p>
+          <div class="flex flex-wrap gap-x-6 gap-y-3">
+            {team.map((member) => (
+              <div class="flex flex-col gap-0.5">
+                <div class="text-brand-200 flex items-center gap-1 text-sm leading-[21px] font-bold">
+                  {member.name}
+                  {member.url && (
+                    <a
+                      href={member.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-brand-200 hover:text-brand-100 transition-colors"
+                    >
+                      <PiArrowSquareOut class="size-[10px]" />
+                    </a>
+                  )}
+                </div>
+                <p class="text-brand-200 text-xs leading-[18px] font-normal">
+                  {member.title}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+    }
+  </div>
+
+  <!-- Visual slot -->
+  {
+    Astro.slots.has('visual') && (
+      <div class="min-w-0 flex-1">
+        <slot name="visual" />
+      </div>
+    )
+  }
+</div>

--- a/src/components/blog-post/scratch-section.astro
+++ b/src/components/blog-post/scratch-section.astro
@@ -1,0 +1,26 @@
+---
+import { cn } from '@/lib/tailwind/utils';
+import { ScratchFull } from '@/components/ui/scratch';
+
+interface Props {
+  class?: string;
+}
+
+const { class: className } = Astro.props;
+---
+
+<div
+  data-slot="scratch-section"
+  class={cn(
+    'not-prose relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen my-12',
+    className
+  )}
+>
+  <ScratchFull className="text-foreground" />
+  <div class="bg-foreground py-16">
+    <div class="container mx-auto px-8">
+      <slot />
+    </div>
+  </div>
+  <ScratchFull className="text-foreground rotate-180" />
+</div>

--- a/src/components/blog-post/stat-card.astro
+++ b/src/components/blog-post/stat-card.astro
@@ -14,7 +14,7 @@ const { value, title, label, class: className } = Astro.props;
 <div
   data-slot="stat-card"
   class={cn(
-    'not-prose inline-flex flex-col items-center justify-center gap-1 self-stretch rounded-md bg-brand-700 p-4 text-center border border-brand-600',
+    'not-prose inline-flex flex-col items-center justify-center gap-1 self-stretch rounded-md bg-brand-700 px-6 py-5 text-center border border-brand-600',
     className
   )}
 >

--- a/src/components/blog-post/stat-card.astro
+++ b/src/components/blog-post/stat-card.astro
@@ -1,0 +1,57 @@
+---
+import { cn } from '@/lib/tailwind/utils';
+
+interface Props {
+  value: string;
+  title?: string;
+  label?: string;
+  class?: string;
+}
+
+const { value, title, label, class: className } = Astro.props;
+---
+
+<div
+  data-slot="stat-card"
+  class={cn(
+    'not-prose inline-flex flex-col items-center justify-center gap-1 self-stretch rounded-md bg-brand-700 p-4 text-center border border-brand-600',
+    className
+  )}
+>
+  <p
+    data-slot="stat-card-value"
+    class="font-heading text-brand-100 text-3xl font-semibold"
+  >
+    {value}
+  </p>
+
+  {
+    Astro.slots.has('visual') ? (
+      <div
+        data-slot="stat-card-visual"
+        class="text-accent flex items-center gap-0.5"
+      >
+        <slot name="visual" />
+      </div>
+    ) : null
+  }
+
+  {
+    title ? (
+      <p
+        data-slot="stat-card-title"
+        class="text-brand-100 text-sm font-semibold"
+      >
+        {title}
+      </p>
+    ) : null
+  }
+
+  {
+    label ? (
+      <p data-slot="stat-card-label" class="text-brand-300 text-xs font-light">
+        {label}
+      </p>
+    ) : null
+  }
+</div>

--- a/src/components/blog-post/testimonial-card.astro
+++ b/src/components/blog-post/testimonial-card.astro
@@ -20,6 +20,8 @@ const initials = person.name
   .join('')
   .slice(0, 2)
   .toUpperCase();
+
+const stars = [1, 2, 3, 4, 5];
 ---
 
 <div
@@ -53,10 +55,10 @@ const initials = person.name
 
   <div class="flex gap-0.5">
     {
-      Array.from({ length: 5 }).map((_, i) => (
+      stars.map((i) => (
         <svg
           viewBox="0 0 16 16"
-          class={cn('size-4', i < rating ? 'text-accent' : 'text-brand-600')}
+          class={cn('size-4', i <= rating ? 'text-accent' : 'text-brand-600')}
           fill="currentColor"
         >
           <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 11.933l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />

--- a/src/components/blog-post/testimonial-card.astro
+++ b/src/components/blog-post/testimonial-card.astro
@@ -30,7 +30,7 @@ const emptyStars = 5 - filledStars;
 <div
   data-slot="testimonial-card"
   class={cn(
-    'not-prose inline-flex flex-col gap-3 self-stretch rounded-md border border-brand-600 bg-brand-700 p-4',
+    'not-prose inline-flex min-w-72 flex-col gap-3 self-stretch rounded-md border border-brand-600 bg-brand-700 px-8 py-6',
     className
   )}
 >

--- a/src/components/blog-post/testimonial-card.astro
+++ b/src/components/blog-post/testimonial-card.astro
@@ -1,4 +1,6 @@
 ---
+import { PiStarFill } from 'react-icons/pi';
+
 import { cn } from '@/lib/tailwind/utils';
 
 interface Props {
@@ -21,7 +23,8 @@ const initials = person.name
   .slice(0, 2)
   .toUpperCase();
 
-const stars = [1, 2, 3, 4, 5];
+const filledStars = Math.min(5, Math.max(0, Math.round(rating)));
+const emptyStars = 5 - filledStars;
 ---
 
 <div
@@ -53,17 +56,16 @@ const stars = [1, 2, 3, 4, 5];
     </div>
   </div>
 
-  <div class="flex gap-0.5">
+  <div class="text-accent flex gap-0.5 [&>svg]:size-4">
     {
-      stars.map((i) => (
-        <svg
-          viewBox="0 0 16 16"
-          class={cn('size-4', i <= rating ? 'text-accent' : 'text-brand-600')}
-          fill="currentColor"
-        >
-          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 11.933l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-        </svg>
-      ))
+      Array(filledStars)
+        .fill(null)
+        .map(() => <PiStarFill />)
+    }
+    {
+      Array(emptyStars)
+        .fill(null)
+        .map(() => <PiStarFill className="text-brand-600" />)
     }
   </div>
 

--- a/src/components/blog-post/testimonial-card.astro
+++ b/src/components/blog-post/testimonial-card.astro
@@ -1,0 +1,69 @@
+---
+import { cn } from '@/lib/tailwind/utils';
+
+interface Props {
+  person: {
+    name: string;
+    avatarUrl?: string;
+  };
+  date: string;
+  rating?: number;
+  content: string;
+  class?: string;
+}
+
+const { person, date, rating = 5, content, class: className } = Astro.props;
+
+const initials = person.name
+  .split(' ')
+  .map((n) => n[0])
+  .join('')
+  .slice(0, 2)
+  .toUpperCase();
+---
+
+<div
+  data-slot="testimonial-card"
+  class={cn(
+    'not-prose inline-flex flex-col gap-3 self-stretch rounded-md border border-brand-600 bg-brand-700 p-4',
+    className
+  )}
+>
+  <div class="flex items-center gap-3">
+    {
+      person.avatarUrl ? (
+        <img
+          src={person.avatarUrl}
+          alt={person.name}
+          class="size-9 shrink-0 rounded-full object-cover"
+        />
+      ) : (
+        <div class="bg-brand-500 text-brand-100 flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold">
+          {initials}
+        </div>
+      )
+    }
+    <div class="flex flex-col gap-0.5">
+      <p class="text-brand-100 text-sm leading-none font-semibold">
+        {person.name}
+      </p>
+      <p class="text-brand-400 text-xs font-light">{date}</p>
+    </div>
+  </div>
+
+  <div class="flex gap-0.5">
+    {
+      Array.from({ length: 5 }).map((_, i) => (
+        <svg
+          viewBox="0 0 16 16"
+          class={cn('size-4', i < rating ? 'text-accent' : 'text-brand-600')}
+          fill="currentColor"
+        >
+          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 11.933l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+        </svg>
+      ))
+    }
+  </div>
+
+  <p class="text-brand-200 text-xs leading-relaxed font-light">{content}</p>
+</div>

--- a/src/components/blog-post/testimonial-list.astro
+++ b/src/components/blog-post/testimonial-list.astro
@@ -10,7 +10,16 @@ const { class: className } = Astro.props;
 
 <div
   data-slot="testimonial-list"
-  class={cn('not-prose flex gap-4 overflow-x-auto pb-2', className)}
+  class={cn('not-prose flex gap-4 overflow-x-auto', className)}
 >
   <slot />
 </div>
+
+<style>
+  [data-slot='testimonial-list'] {
+    scrollbar-width: none;
+  }
+  [data-slot='testimonial-list']::-webkit-scrollbar {
+    display: none;
+  }
+</style>

--- a/src/components/blog-post/testimonial-list.astro
+++ b/src/components/blog-post/testimonial-list.astro
@@ -1,0 +1,16 @@
+---
+import { cn } from '@/lib/tailwind/utils';
+
+interface Props {
+  class?: string;
+}
+
+const { class: className } = Astro.props;
+---
+
+<div
+  data-slot="testimonial-list"
+  class={cn('not-prose flex gap-4 overflow-x-auto pb-2', className)}
+>
+  <slot />
+</div>

--- a/src/components/blog-post/two-columns.astro
+++ b/src/components/blog-post/two-columns.astro
@@ -1,0 +1,78 @@
+---
+import { cva } from 'class-variance-authority';
+
+import { cn } from '@/lib/tailwind/utils';
+
+type ColRatio = '1/2' | '1/3' | '2/3' | '1/4' | '3/4';
+
+interface Props {
+  leftRatio?: ColRatio;
+  align?: 'start' | 'center' | 'end';
+  reverse?: boolean;
+  gap?: 'sm' | 'md' | 'lg';
+  class?: string;
+}
+
+const {
+  leftRatio = '1/2',
+  align = 'start',
+  reverse = false,
+  gap = 'md',
+  class: className,
+} = Astro.props;
+
+const wrapper = cva('not-prose flex w-full flex-col md:flex-row', {
+  variants: {
+    align: {
+      start: 'items-start',
+      center: 'items-center',
+      end: 'items-end',
+    },
+    gap: {
+      sm: 'gap-4',
+      md: 'gap-8',
+      lg: 'gap-12',
+    },
+  },
+});
+
+const leftCol = cva('w-full', {
+  variants: {
+    ratio: {
+      '1/2': 'md:w-1/2',
+      '1/3': 'md:w-1/3',
+      '2/3': 'md:w-2/3',
+      '1/4': 'md:w-1/4',
+      '3/4': 'md:w-3/4',
+    },
+  },
+});
+
+const rightCol = cva('w-full', {
+  variants: {
+    ratio: {
+      '1/2': 'md:w-1/2',
+      '1/3': 'md:w-2/3',
+      '2/3': 'md:w-1/3',
+      '1/4': 'md:w-3/4',
+      '3/4': 'md:w-1/4',
+    },
+  },
+});
+---
+
+<div
+  data-slot="two-columns"
+  class={cn(
+    wrapper({ align, gap }),
+    reverse && 'md:flex-row-reverse',
+    className
+  )}
+>
+  <div data-slot="two-columns-left" class={leftCol({ ratio: leftRatio })}>
+    <slot name="left" />
+  </div>
+  <div data-slot="two-columns-right" class={rightCol({ ratio: leftRatio })}>
+    <slot name="right" />
+  </div>
+</div>

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -29,6 +29,14 @@ import RootLayout from '@/layouts/root-layout.astro';
   <div class="container mx-auto flex flex-col gap-8 p-8">
     <h1 class="font-heading text-4xl font-bold">Styleguide</h1>
 
+    <div class="flex flex-wrap gap-2">
+      <a
+        href="/styleguide/blog-post"
+        class="rounded-md border border-gray-200 px-3 py-1.5 text-sm hover:bg-gray-50"
+        >Blog Post Components →</a
+      >
+    </div>
+
     <!-- -->
 
     <div class="flex flex-col gap-4">

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -3,6 +3,7 @@ import { LuCalendar, LuImage, LuType } from 'react-icons/lu';
 import { PiStarFill, PiStarHalfFill } from 'react-icons/pi';
 
 import FeatureCard from '@/components/blog-post/feature-card.astro';
+import { PhoneCarousel } from '@/components/blog-post/phone-carousel';
 import StatCard from '@/components/blog-post/stat-card.astro';
 import TestimonialCard from '@/components/blog-post/testimonial-card.astro';
 import RootLayout from '@/layouts/root-layout.astro';
@@ -15,6 +16,52 @@ import RootLayout from '@/layouts/root-layout.astro';
         >← Styleguide</a
       >
       <h1 class="font-heading text-4xl font-bold">Blog Post Components</h1>
+    </div>
+
+    <!-- Phone Carousel -->
+
+    <div class="flex flex-col gap-4">
+      <h2 class="font-heading text-xl font-bold">Phone Carousel</h2>
+
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <PhoneCarousel
+          client:load
+          slides={[
+            {
+              src: 'https://placehold.co/440x956/e2e8f0/94a3b8?text=Screen+1',
+              alt: 'Écran 1',
+            },
+            {
+              src: 'https://placehold.co/440x956/dbeafe/60a5fa?text=Screen+2',
+              alt: 'Écran 2',
+            },
+            {
+              src: 'https://placehold.co/440x956/dcfce7/4ade80?text=Screen+3',
+              alt: 'Écran 3',
+            },
+          ]}
+        />
+      </div>
+
+      <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
+        <PhoneCarousel
+          client:load
+          slides={[
+            {
+              src: 'https://placehold.co/440x956/e2e8f0/94a3b8?text=Screen+1',
+              alt: 'Écran 1',
+            },
+            {
+              src: 'https://placehold.co/440x956/dbeafe/60a5fa?text=Screen+2',
+              alt: 'Écran 2',
+            },
+            {
+              src: 'https://placehold.co/440x956/dcfce7/4ade80?text=Screen+3',
+              alt: 'Écran 3',
+            },
+          ]}
+        />
+      </div>
     </div>
 
     <!-- Feature Card -->

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -4,6 +4,7 @@ import { PiStarFill, PiStarHalfFill } from 'react-icons/pi';
 
 import FeatureCard from '@/components/blog-post/feature-card.astro';
 import StatCard from '@/components/blog-post/stat-card.astro';
+import TestimonialCard from '@/components/blog-post/testimonial-card.astro';
 import RootLayout from '@/layouts/root-layout.astro';
 ---
 
@@ -114,6 +115,46 @@ import RootLayout from '@/layouts/root-layout.astro';
             value="N°16"
             title="Cuisine & Boissons"
             label="Classement App Store"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Testimonial Card -->
+
+    <div class="flex flex-col gap-4">
+      <h2 class="font-heading text-xl font-bold">Testimonial Card</h2>
+
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <div class="grid max-w-xl grid-cols-2 gap-4">
+          <TestimonialCard
+            person={{ name: 'Sara Cookies' }}
+            date="23/05/2025"
+            rating={5}
+            content="Très contente de cette application qui est très complète pour la diversification de mon bébé."
+          />
+          <TestimonialCard
+            person={{ name: 'Marc Dupont' }}
+            date="14/03/2025"
+            rating={4}
+            content="Très bonne application, les recettes sont variées et bien expliquées. Je recommande !"
+          />
+        </div>
+      </div>
+
+      <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
+        <div class="grid max-w-xl grid-cols-2 gap-4">
+          <TestimonialCard
+            person={{ name: 'Sara Cookies' }}
+            date="23/05/2025"
+            rating={5}
+            content="Très contente de cette application qui est très complète pour la diversification de mon bébé."
+          />
+          <TestimonialCard
+            person={{ name: 'Marc Dupont' }}
+            date="14/03/2025"
+            rating={4}
+            content="Très bonne application, les recettes sont variées et bien expliquées. Je recommande !"
           />
         </div>
       </div>

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -4,6 +4,7 @@ import { PiStarFill, PiStarHalfFill } from 'react-icons/pi';
 
 import FeatureCard from '@/components/blog-post/feature-card.astro';
 import { PhoneCarousel } from '@/components/blog-post/phone-carousel';
+import ScratchSection from '@/components/blog-post/scratch-section.astro';
 import StatCard from '@/components/blog-post/stat-card.astro';
 import TestimonialCard from '@/components/blog-post/testimonial-card.astro';
 import TwoColumns from '@/components/blog-post/two-columns.astro';
@@ -153,6 +154,21 @@ import RootLayout from '@/layouts/root-layout.astro';
         />
       </div>
     </div>
+
+    <!-- Scratch Section -->
+
+    <div class="flex flex-col gap-4">
+      <h2 class="font-heading text-xl font-bold">Scratch Section</h2>
+    </div>
+
+    <ScratchSection>
+      <p class="font-heading text-brand-100 text-2xl font-semibold">
+        Titre de section
+      </p>
+      <p class="text-brand-300 mt-2 text-sm">
+        Contenu de la section sur fond sombre avec déchirures en haut et en bas.
+      </p>
+    </ScratchSection>
 
     <!-- Feature Card -->
 

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -1,9 +1,10 @@
 ---
-import { LuCalendar, LuImage, LuType } from 'react-icons/lu';
+import { LuCalendar, LuImage, LuLayoutDashboard, LuType } from 'react-icons/lu';
 import { PiStarFill, PiStarHalfFill } from 'react-icons/pi';
 
 import FeatureCard from '@/components/blog-post/feature-card.astro';
 import { PhoneCarousel } from '@/components/blog-post/phone-carousel';
+import RoleCard from '@/components/blog-post/role-card.astro';
 import ScratchSection from '@/components/blog-post/scratch-section.astro';
 import StatCard from '@/components/blog-post/stat-card.astro';
 import TestimonialCard from '@/components/blog-post/testimonial-card.astro';
@@ -169,6 +170,34 @@ import RootLayout from '@/layouts/root-layout.astro';
         Contenu de la section sur fond sombre avec déchirures en haut et en bas.
       </p>
     </ScratchSection>
+
+    <!-- Role Card -->
+
+    <div class="flex flex-col gap-4">
+      <h2 class="font-heading text-xl font-bold">Role Card</h2>
+
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <RoleCard
+          icon={LuLayoutDashboard}
+          role="Product Design"
+          description="Notre équipe a participé à la conception de l'expérience mobile à partir de l'analyse des besoins utilisateurs. Et participe également à la structuration des parcours et réalisation de prototypes basse et haute fidélité, avec des itérations pour valider les choix de conception."
+          tags={['Figma', 'UX/UI', 'Maquettes']}
+          team={[
+            { name: 'Ivan D.', title: 'Lead Designer UX/UI', url: '#' },
+            { name: 'Daryl A.', title: 'UX/UI Designer', url: '#' },
+            { name: 'Dorian D.', title: 'UX/UI Designer' },
+          ]}
+        >
+          <div slot="visual" class="h-full w-full overflow-hidden rounded-md">
+            <img
+              src="https://placehold.co/800x500/1a3a42/4a9aaa?text=Illustration"
+              class="h-full w-full rounded-md object-cover"
+              alt=""
+            />
+          </div>
+        </RoleCard>
+      </div>
+    </div>
 
     <!-- Feature Card -->
 

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -1,0 +1,44 @@
+---
+import { LuCalendar, LuImage, LuType } from 'react-icons/lu';
+
+import FeatureCard from '@/components/blog-post/feature-card.astro';
+import RootLayout from '@/layouts/root-layout.astro';
+---
+
+<RootLayout>
+  <div class="container mx-auto flex flex-col gap-12 p-8">
+    <div class="flex flex-col gap-1">
+      <a href="/styleguide" class="text-sm text-neutral-500 hover:underline"
+        >← Styleguide</a
+      >
+      <h1 class="font-heading text-4xl font-bold">Blog Post Components</h1>
+    </div>
+
+    <!-- Feature Card -->
+
+    <div class="flex flex-col gap-4">
+      <h2 class="font-heading text-xl font-bold">Feature Card</h2>
+
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <div class="grid max-w-xl grid-cols-2 gap-4">
+          <FeatureCard
+            icon={LuCalendar}
+            title="Âge présent mais secondaire"
+            content="Visible, sans voler l'attention"
+          />
+
+          <FeatureCard
+            icon={LuType}
+            title="Titre optimisé"
+            content="Typographie, espace, nombre de lignes soigneusement pensés"
+          />
+          <FeatureCard
+            icon={LuImage}
+            title="Image dominante"
+            content="L'œil décide d'abord par le visuel, un parti pris rendu évident par la richesse et la qualité exceptionnelle des photos"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</RootLayout>

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -6,6 +6,7 @@ import FeatureCard from '@/components/blog-post/feature-card.astro';
 import { PhoneCarousel } from '@/components/blog-post/phone-carousel';
 import StatCard from '@/components/blog-post/stat-card.astro';
 import TestimonialCard from '@/components/blog-post/testimonial-card.astro';
+import TwoColumns from '@/components/blog-post/two-columns.astro';
 import RootLayout from '@/layouts/root-layout.astro';
 ---
 
@@ -16,6 +17,94 @@ import RootLayout from '@/layouts/root-layout.astro';
         >← Styleguide</a
       >
       <h1 class="font-heading text-4xl font-bold">Blog Post Components</h1>
+    </div>
+
+    <!-- Two Columns -->
+
+    <div class="flex flex-col gap-4">
+      <h2 class="font-heading text-xl font-bold">Two Columns</h2>
+
+      <p class="text-sm text-neutral-500">1/2 + 1/2 (défaut)</p>
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <TwoColumns>
+          <div slot="left" class="flex flex-col gap-2">
+            <p class="font-heading text-lg font-semibold">Colonne texte</p>
+            <p class="text-sm text-neutral-600">
+              Un paragraphe d'explication ou de description pour accompagner
+              l'illustration à droite.
+            </p>
+          </div>
+          <div
+            slot="right"
+            class="flex aspect-video w-full items-center justify-center rounded-lg bg-neutral-100 text-sm text-neutral-400"
+          >
+            Illustration
+          </div>
+        </TwoColumns>
+      </div>
+
+      <p class="text-sm text-neutral-500">
+        1/3 texte + 2/3 illustration, alignement centré
+      </p>
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <TwoColumns leftRatio="1/3" align="center">
+          <div slot="left" class="flex flex-col gap-2">
+            <p class="font-heading text-lg font-semibold">Texte étroit</p>
+            <p class="text-sm text-neutral-600">
+              Illustration dominante sur la droite.
+            </p>
+          </div>
+          <div
+            slot="right"
+            class="flex aspect-video w-full items-center justify-center rounded-lg bg-neutral-100 text-sm text-neutral-400"
+          >
+            Grande illustration
+          </div>
+        </TwoColumns>
+      </div>
+
+      <p class="text-sm text-neutral-500">
+        2/3 texte + 1/3 illustration, inversé (illustration à gauche)
+      </p>
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <TwoColumns leftRatio="2/3" reverse align="center">
+          <div slot="left" class="flex flex-col gap-2">
+            <p class="font-heading text-lg font-semibold">Texte dominant</p>
+            <p class="text-sm text-neutral-600">
+              L'illustration est visuellement à gauche grâce à <code
+                >reverse</code
+              >, mais le slot reste <code>right</code> dans le markup.
+            </p>
+          </div>
+          <div
+            slot="right"
+            class="flex aspect-square w-full items-center justify-center rounded-lg bg-neutral-100 text-sm text-neutral-400"
+          >
+            Miniature
+          </div>
+        </TwoColumns>
+      </div>
+
+      <p class="text-sm text-neutral-500">Sur fond sombre</p>
+      <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
+        <TwoColumns align="center">
+          <div slot="left" class="flex flex-col gap-2">
+            <p class="font-heading text-brand-100 text-lg font-semibold">
+              Colonne texte
+            </p>
+            <p class="text-brand-300 text-sm">
+              Un paragraphe d'explication ou de description pour accompagner
+              l'illustration à droite.
+            </p>
+          </div>
+          <div
+            slot="right"
+            class="bg-brand-700 text-brand-400 flex aspect-video w-full items-center justify-center rounded-lg text-sm"
+          >
+            Illustration
+          </div>
+        </TwoColumns>
+      </div>
     </div>
 
     <!-- Phone Carousel -->
@@ -46,6 +135,7 @@ import RootLayout from '@/layouts/root-layout.astro';
       <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
         <PhoneCarousel
           client:load
+          dark
           slides={[
             {
               src: 'https://placehold.co/440x956/e2e8f0/94a3b8?text=Screen+1',

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -8,6 +8,7 @@ import RoleCard from '@/components/blog-post/role-card.astro';
 import ScratchSection from '@/components/blog-post/scratch-section.astro';
 import StatCard from '@/components/blog-post/stat-card.astro';
 import TestimonialCard from '@/components/blog-post/testimonial-card.astro';
+import TestimonialList from '@/components/blog-post/testimonial-list.astro';
 import TwoColumns from '@/components/blog-post/two-columns.astro';
 import RootLayout from '@/layouts/root-layout.astro';
 ---
@@ -205,7 +206,7 @@ import RootLayout from '@/layouts/root-layout.astro';
       <h2 class="font-heading text-xl font-bold">Feature Card</h2>
 
       <div class="rounded-xl border border-neutral-200 p-8">
-        <div class="grid max-w-xl grid-cols-2 gap-4">
+        <div class="grid max-w-xl grid-cols-1 gap-4 sm:grid-cols-2">
           <FeatureCard
             icon={LuCalendar}
             title="Âge présent mais secondaire"
@@ -224,7 +225,7 @@ import RootLayout from '@/layouts/root-layout.astro';
         </div>
       </div>
       <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
-        <div class="grid max-w-xl grid-cols-2 gap-4">
+        <div class="grid max-w-xl grid-cols-1 gap-4 sm:grid-cols-2">
           <FeatureCard
             icon={LuCalendar}
             title="Âge présent mais secondaire"
@@ -308,7 +309,7 @@ import RootLayout from '@/layouts/root-layout.astro';
       <h2 class="font-heading text-xl font-bold">Testimonial Card</h2>
 
       <div class="rounded-xl border border-neutral-200 p-8">
-        <div class="grid max-w-xl grid-cols-2 gap-4">
+        <TestimonialList>
           <TestimonialCard
             person={{ name: 'Sara Cookies' }}
             date="23/05/2025"
@@ -321,11 +322,17 @@ import RootLayout from '@/layouts/root-layout.astro';
             rating={4}
             content="Très bonne application, les recettes sont variées et bien expliquées. Je recommande !"
           />
-        </div>
+          <TestimonialCard
+            person={{ name: 'Julie M.' }}
+            date="01/01/2025"
+            rating={5}
+            content="Super application, je l'utilise tous les jours pour mes enfants."
+          />
+        </TestimonialList>
       </div>
 
       <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
-        <div class="grid max-w-xl grid-cols-2 gap-4">
+        <TestimonialList>
           <TestimonialCard
             person={{ name: 'Sara Cookies' }}
             date="23/05/2025"
@@ -338,7 +345,13 @@ import RootLayout from '@/layouts/root-layout.astro';
             rating={4}
             content="Très bonne application, les recettes sont variées et bien expliquées. Je recommande !"
           />
-        </div>
+          <TestimonialCard
+            person={{ name: 'Julie M.' }}
+            date="01/01/2025"
+            rating={5}
+            content="Super application, je l'utilise tous les jours pour mes enfants."
+          />
+        </TestimonialList>
       </div>
     </div>
   </div>

--- a/src/pages/styleguide/blog-post.astro
+++ b/src/pages/styleguide/blog-post.astro
@@ -1,7 +1,9 @@
 ---
 import { LuCalendar, LuImage, LuType } from 'react-icons/lu';
+import { PiStarFill, PiStarHalfFill } from 'react-icons/pi';
 
 import FeatureCard from '@/components/blog-post/feature-card.astro';
+import StatCard from '@/components/blog-post/stat-card.astro';
 import RootLayout from '@/layouts/root-layout.astro';
 ---
 
@@ -26,7 +28,6 @@ import RootLayout from '@/layouts/root-layout.astro';
             title="Âge présent mais secondaire"
             content="Visible, sans voler l'attention"
           />
-
           <FeatureCard
             icon={LuType}
             title="Titre optimisé"
@@ -36,6 +37,83 @@ import RootLayout from '@/layouts/root-layout.astro';
             icon={LuImage}
             title="Image dominante"
             content="L'œil décide d'abord par le visuel, un parti pris rendu évident par la richesse et la qualité exceptionnelle des photos"
+          />
+        </div>
+      </div>
+      <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
+        <div class="grid max-w-xl grid-cols-2 gap-4">
+          <FeatureCard
+            icon={LuCalendar}
+            title="Âge présent mais secondaire"
+            content="Visible, sans voler l'attention"
+          />
+          <FeatureCard
+            icon={LuType}
+            title="Titre optimisé"
+            content="Typographie, espace, nombre de lignes soigneusement pensés"
+          />
+          <FeatureCard
+            icon={LuImage}
+            title="Image dominante"
+            content="L'œil décide d'abord par le visuel, un parti pris rendu évident par la richesse et la qualité exceptionnelle des photos"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Stat Card -->
+
+    <div class="flex flex-col gap-4">
+      <h2 class="font-heading text-xl font-bold">Stat Card</h2>
+
+      <div class="rounded-xl border border-neutral-200 p-8">
+        <div class="grid max-w-xl grid-cols-2 gap-4">
+          <StatCard value="4,8" label="1,1k notes">
+            <PiStarFill slot="visual" />
+          </StatCard>
+          <StatCard
+            value="+ 500 k"
+            title="Téléchargements"
+            label="Sur iOS & Android"
+          />
+          <StatCard
+            value="N°2"
+            title="Alimentation & Boissons"
+            label="Classement Google Play"
+          />
+          <StatCard
+            value="N°16"
+            title="Cuisine & Boissons"
+            label="Classement App Store"
+          />
+        </div>
+      </div>
+
+      <div class="bg-foreground rounded-xl border border-neutral-200 p-8">
+        <div class="grid max-w-xl grid-cols-2 gap-4">
+          <StatCard value="4,8" label="1,1k notes">
+            <Fragment slot="visual">
+              <PiStarFill />
+              <PiStarFill />
+              <PiStarFill />
+              <PiStarFill />
+              <PiStarHalfFill />
+            </Fragment>
+          </StatCard>
+          <StatCard
+            value="+ 500 k"
+            title="Téléchargements"
+            label="Sur iOS & Android"
+          />
+          <StatCard
+            value="N°2"
+            title="Alimentation & Boissons"
+            label="Classement Google Play"
+          />
+          <StatCard
+            value="N°16"
+            title="Cuisine & Boissons"
+            label="Classement App Store"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- New blog-post components for use in MDX articles: `PhoneCarousel`, `ScratchSection`, `RoleCard`, `FeatureCard`, `StatCard`, `TestimonialCard` + `TestimonialList`, `TwoColumns`
- All components added to `/styleguide/blog-post` with light and dark variants
- Responsive layouts (mobile-first)

## Components

| Component | Description |
|---|---|
| `PhoneCarousel` | React carousel with phone frame mockup, dot indicators, dark mode support |
| `ScratchSection` | Full-width dark section with torn-paper edges |
| `RoleCard` | Role presentation card with icon, tags, team members, and visual slot |
| `FeatureCard` | Icon + title + description card |
| `StatCard` | Stat highlight card with visual slot |
| `TestimonialCard` + `TestimonialList` | Review card in horizontal scroll container |
| `TwoColumns` | Two-column layout with ratio and reverse props |

## Test plan

- [ ] Visit `/styleguide/blog-post` and review all components
- [ ] Check responsive behavior on mobile (< lg)
- [ ] Check dark variants render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)